### PR TITLE
Add a new Gateways class to handle the locale code of Paypal checkout

### DIFF
--- a/src/Hyyan/WPI/Gateways.php
+++ b/src/Hyyan/WPI/Gateways.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the hyyan/woo-poly-integration plugin.
+ * (c) Hyyan Abo Fakher <tiribthea4hyyan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hyyan\WPI;
+
+/**
+ * Gateways
+ *
+ * Handle Payment Gateways
+ *
+ * @author Nicolas Joannès <nic@cobea.be>
+ */
+class Gateways
+{
+
+
+    /**
+     * Construct object
+     */
+    public function __construct()
+    {
+        add_filter('woocommerce_paypal_args', array($this, 'setPaypalLocalCode'));
+
+    }
+
+
+    /**
+     * Set the PayPal checkout locale code
+     *
+     * @param array $args the current paypal request args array
+     *
+     * @return void
+     */
+    public function setPaypalLocalCode($args)
+    {
+        $lang = pll_current_language('locale');
+        $args['locale.x'] = $lang;
+
+        return $args;
+
+    }
+
+
+}

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -154,6 +154,7 @@ class Plugin
         new Reports();
         new Widgets\SearchWidget();
         new Widgets\LayeredNav();
+        new Gateways();
     }
 
 }


### PR DESCRIPTION
Hello Hyyan,

I've just added a new Gateways class to handle the locale code of Paypal checkout. The class hooks on the builtin woocommerce "woocommerce_paypal_args" filter to add an extra argument "locale.x" with the current value of pll locale. In this way the Paypal checkout is on the same language that the current pll language.

Regards