### PR TITLE
Update TranslationsDownloader.php

### DIFF
--- a/src/Hyyan/WPI/Tools/TranslationsDownloader.php
+++ b/src/Hyyan/WPI/Tools/TranslationsDownloader.php
@@ -154,7 +154,7 @@ class TranslationsDownloader
     public static function getRepoUrl()
     {
         $url = sprintf(
-                'https://github.com/woothemes/woocommerce-language-packs/raw/v%s/packages'
+                'https://downloads.wordpress.org/translation/plugin/woocommerce/%s'
                 , WC()->version
         );
 


### PR DESCRIPTION
Original repository is deprecated. And while url is not updated we are not able to add languages automatically without using filter "woo-poly.language.repoUrl".