### PR TITLE
Shipping fix

### DIFF
--- a/src/Hyyan/WPI/Admin/Features.php
+++ b/src/Hyyan/WPI/Admin/Features.php
@@ -10,6 +10,8 @@
 
 namespace Hyyan\WPI\Admin;
 
+use Hyyan\WPI\Utilities;
+
 /**
  * Features
  *
@@ -76,7 +78,7 @@ class Features extends AbstractSettings
                 'default' => 'on',
                 'label' => __('Reports', 'woo-poly-integration'),
                 'desc' => __(
-                        'Enable reports langauge filtering and combining'
+                        'Enable reports language filtering and combining'
                         , 'woo-poly-integration'
                 )
             ),
@@ -126,7 +128,7 @@ class Features extends AbstractSettings
                 'default' => 'on',
                 'label' => __('Translate Attributes', 'woo-poly-integration'),
                 'desc' => __(
-                        'Enable Attributes translations'
+                        'Enable attributes translations'
                         , 'woo-poly-integration'
                 )
             ),
@@ -134,9 +136,9 @@ class Features extends AbstractSettings
                 'name' => 'shipping-class',
                 'type' => 'checkbox',
                 'default' => 'off',
-                'label' => __('Translate ShippingClass', 'woo-poly-integration'),
+                'label' => __('Translate Shipping Classes', 'woo-poly-integration'),
                 'desc' => __(
-                        'Enable ShippingClass translations'
+                        'Enable shipping classes translations' . ( Utilities::woocommerceVersionCheck( '2.6' ) ? ' (not supported for WooCommerce versions >= 2.6)' : '' )
                         , 'woo-poly-integration'
                 )
             )

--- a/src/Hyyan/WPI/Admin/MetasList.php
+++ b/src/Hyyan/WPI/Admin/MetasList.php
@@ -78,7 +78,7 @@ class MetasList extends AbstractSettings
     }
 
     /**
-     * Normalize string by removing "_", and leading ans trailing spaces from string
+     * Normalize string by removing "_", and leading and trailing spaces from string
      *
      * @param string $string
      *

--- a/src/Hyyan/WPI/Admin/MetasList.php
+++ b/src/Hyyan/WPI/Admin/MetasList.php
@@ -37,9 +37,12 @@ class MetasList extends AbstractSettings
             array(
                 'title' => __('Metas List', 'woo-poly-integration'),
                 'desc' => __(
-                        'The section will allow you to controll which metas should be
-                         synced between product and its translation , please ignore
-                         this section if you do not understand the meaning of this.
+                        'The section will allow you to control which metas should be
+                         synced between products and their translations. The default
+                         values are appropriate for the large majority of the users.
+                         It is safe to ignore these settings if you do not understand
+                         their meaning.Please ignore this section if you do not
+                         understand the meaning of this.
                         '
                         , 'woo-poly-integration'
                 )
@@ -75,7 +78,7 @@ class MetasList extends AbstractSettings
     }
 
     /**
-     * Normalize string by removing "_" from string
+     * Normalize string by removing "_", and leading ans trailing spaces from string
      *
      * @param string $string
      *
@@ -83,7 +86,7 @@ class MetasList extends AbstractSettings
      */
     public static function normalize($string)
     {
-        return ucwords(str_replace('_', ' ', $string));
+        return ucwords( trim( str_replace( '_', ' ', $string ) ) );
     }
 
 }

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -164,6 +164,7 @@ class Plugin
         new Widgets\SearchWidget();
         new Widgets\LayeredNav();
         new Gateways();
+        new Shipping();
     }
 
 }

--- a/src/Hyyan/WPI/Shipping.php
+++ b/src/Hyyan/WPI/Shipping.php
@@ -31,7 +31,7 @@ class Shipping
 
         // Shipping Class translation is not supported after WooCommerce 2.6
         // Note: WooCommerce change the Shipping Class interface and is no longer
-        // using the same actions and filters as WordPress. Therefore PolylanTo
+        // using the same actions and filters as WordPress. Therefore Polylang
         // can't display the languages columns and metabox for custom post types
         // and taxonomies.
         if ( Utilities::woocommerceVersionCheck( '2.6' ) ) {

--- a/src/Hyyan/WPI/Shipping.php
+++ b/src/Hyyan/WPI/Shipping.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * This file is part of the hyyan/woo-poly-integration plugin.
+ * (c) Hyyan Abo Fakher <tiribthea4hyyan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hyyan\WPI;
+
+use Hyyan\WPI\Utilities,
+    Hyyan\WPI\Admin\Settings,
+    Hyyan\WPI\Admin\Features;
+
+/**
+ * Shipping
+ *
+ * Handle Shipping Methods
+ *
+ * @author Antonio de Carvalho <decarvalhoaa@gmail.com>
+ */
+class Shipping
+{
+
+    /**
+     * Construct object
+     */
+    public function __construct() {
+
+        // Shipping Class translation is not supported after WooCommerce 2.6
+        // Note: WooCommerce change the Shipping Class interface and is no longer
+        // using the same actions and filters as WordPress. Therefore PolylanTo
+        // can't display the languages columns and metabox for custom post types
+        // and taxonomies.
+        if ( Utilities::woocommerceVersionCheck( '2.6' ) ) {
+
+            // Force shipping class translation feature to off
+            if ( 'off' !== Settings::getOption( 'shipping-class', Features::getID() ) ) {
+                $settings = get_option( Features::getID() );
+                $settings['shipping-class'] =  'off';
+                update_option( Features::getID(), $settings );
+            }
+
+            // Disable shipping class translation feature input selector
+            add_action( 'current_screen', array( $this, 'disableSettings' ) );
+
+        }
+
+        // Register woocommerce shipping method custom names in polylang strings translations table
+        add_action( 'wp_loaded', array( $this, 'registerShippingStringsForTranslation' ) ); // called only after Wordpress is loaded
+
+        // Shipping method in the Cart and Checkout pages
+        add_filter( 'woocommerce_shipping_rate_label', array( $this, 'translateShippingLabel' ), 10, 1 );
+
+        // Shipping method in My Account page, Order Emails and Paypal requests
+        add_filter( 'woocommerce_order_shipping_method', array( $this, 'translateOrderShippingMethod' ), 10, 2 );
+
+    }
+
+    /**
+     * Disable Settings
+     *
+     * @return false if the current post type is not "product"
+     */
+    public function disableSettings() {
+
+        $currentScreen = get_current_screen();
+        if ( $currentScreen->id !== 'settings_page_hyyan-wpi' )
+            return false;
+
+        add_action( 'admin_print_scripts', array( $this, 'disableShippingClassFeature' ), 100 );
+    }
+
+    /**
+     * Add the disable Shipping Class translation feature script
+     *
+     * The script will disable enabling the Shipping Class translation feature
+     */
+    public function disableShippingClassFeature() {
+
+        $jsID = 'shipping-class-translation-disabled';
+        $code = '$( "#wpuf-wpi-features\\\[shipping-class\\\]" ).prop( "disabled", true );';
+
+        // To use any of the meta-characters ( such as !"#$%&'()*+,./:;<=>?@[]^`{|}~ )
+        // as a literal part of a name, it must be escaped with with two backslashes: \\.
+        // Because jsScriptWrapper() uses sprintf() it will treat one backslash as escape
+        // character, so we need to add a 3rd (crazy!) backslashes.
+
+        Utilities::jsScriptWrapper( $jsID, $code );
+    }
+
+    /**
+    * Helper function - Gets the shipping methods enabled in the shop
+    *
+    * @return array $active_methods The id and respective plugin id of all active methods
+    */
+    private function getActiveShippingMethods() {
+
+        $active_methods = array();
+
+        if ( Utilities::woocommerceVersionCheck( '2.6' ) ) {
+            //  WooCommerce 2.6 intoduces the concept of Shipping Zones
+
+            // Format:  $shipping_methods[zone_name_method_id] => shipping_method_object
+            // where zone_name is e.g. domestic, europe, rest_of_the_world, and
+            // methods_id is e.g. flat_rate, free_shiping, local_pickup, etc
+            $shipping_methods = $this->getZonesShippingMethods();
+
+        } else {
+
+            // Format:  $shipping_methods[method_id] => shipping_method_object
+            // where methods_id is e.g. flat_rate, free_shiping, local_pickup, etc
+            $shipping_methods = WC()->shipping->load_shipping_methods();
+
+        }
+
+       foreach ( $shipping_methods as $id => $shipping_method ) {
+            if ( isset( $shipping_method->enabled ) && 'yes' === $shipping_method->enabled ) {
+                $active_methods[$id] = $shipping_method->plugin_id;
+            }
+        }
+
+        return $active_methods;
+    }
+
+    /**
+     * Get the shipping methods for all shipping zones
+     *
+     * Note: WooCommerce 2.6 intoduces the concept of Shipping Zones
+     *
+     * @return array (Array of) all shipping methods instances
+     */
+    public function getZonesShippingMethods() {
+
+        $zones = array();
+
+        // Rest of the World zone
+        $zone                                                     = new \WC_Shipping_Zone();
+        $zones[ $zone->get_zone_id() ]                            = $zone->get_data();
+        $zones[ $zone->get_zone_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
+        $zones[ $zone->get_zone_id() ]['shipping_methods']        = $zone->get_shipping_methods();
+
+        // Add user configured zones
+        $zones = array_merge( $zones, \WC_Shipping_Zones::get_zones() );
+
+        $shipping_methods = array();
+
+        // Format:  $shipping_methods[zone_name_method_id] => shipping_method_object
+        // where zone_name is e.g. domestic, europe, rest_of_the_world, and
+        // methods_id is e.g. flat_rate, free_shiping, local_pickup, etc
+        foreach ( $zones as $zone ) {
+            foreach ( $zone['shipping_methods'] as $instance_id => $shipping_method ) {
+                // Zone names are converted to all lower-case and spaces replaced with
+                $shipping_methods[ $shipping_method->id . '_' . $instance_id ] = $shipping_method;
+            }
+        }
+
+        return $shipping_methods;
+    }
+
+    /**
+     * Register shipping method custom titles in Polylang's Strings translations table
+     */
+    public function registerShippingStringsForTranslation() {
+
+        if ( function_exists( 'pll_register_string' ) ) {
+
+            $shipping_methods = $this->getActiveShippingMethods();
+
+            foreach ( $shipping_methods as $method_id => $plugin_id ) {
+                $setting = get_option( $plugin_id . $method_id . '_settings' );
+
+                if ( $setting && isset( $setting['title'] ) ) {
+                    pll_register_string( $plugin_id . $method_id . '_shipping_method', $setting['title'], __( 'Woocommerce Shipping Methods', 'woo-poly-integration') );
+                }
+            }
+
+        }
+    }
+
+    /**
+     * Translate shipping label in the Cart and Checkout pages
+     *
+     * @param string $label Shipping method label
+     *
+     * @return string Translated label
+     */
+    public function translateShippingLabel( $label ) {
+        return function_exists( 'pll__' ) ? pll__( $label ) : __( $label , 'woocommerce' );
+    }
+
+    /**
+     * Translate shipping method title in My Account page, Order Emails and Paypal requests
+     *
+     * @param string $implode Comma separated string of shipping methods used in order
+     * @param WC_Order $instance Order instance
+     *
+     * @return string Comma separated string of translated shipping methods' titles
+     */
+    public function translateOrderShippingMethod( $implode, $instance ) {
+
+        // Convert the imploded array again to an array that is easy to manipulate
+        $shipping_methods = explode( ', ', $implode );
+
+        // Array with translated shipping methods
+        $translated = array();
+
+        foreach ( $shipping_methods as $shipping ) {
+            if ( function_exists( 'pll__' ) ) {
+                $translated[] = pll__( $shipping );
+            } else {
+                $translated[] = __( $shipping, 'woocommerce' );
+            }
+        }
+
+        // Implode array to string again
+        $translated_implode = implode( ', ', $translated );
+
+        return $translated_implode;
+    }
+}

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -26,7 +26,7 @@ final class Utilities
      * @global \Polylang $polylang
      *
      * @param integer $ID             the product ID
-     * @param boolean $excludeDefault ture to exclude defualt language
+     * @param boolean $excludeDefault true to exclude default language
      *
      * @return array associative array with language code as key and ID of translations
      *               as value.
@@ -48,7 +48,7 @@ final class Utilities
      * @see \Hyyan\WPI\getProductTranslationsByID()
      *
      * @param \WC_Product $product        the product object
-     * @param boolean     $excludeDefault ture to exclude defualt language
+     * @param boolean     $excludeDefault true to exclude default language
      *
      * @return array associative array with language code as key and ID of translations
      *               as value.
@@ -59,9 +59,9 @@ final class Utilities
     }
 
     /**
-     * Get porduct translation by ID
+     * Get product translation by ID
      *
-     * @param integer $ID   the porduct ID
+     * @param integer $ID   the product ID
      * @param string  $slug the language slug
      *
      * @return \WC_Product|false product translation if found , false if the
@@ -80,7 +80,7 @@ final class Utilities
     /**
      * Get product translation by object
      *
-     * @param \WC_Product $product the product to use to retirve translation
+     * @param \WC_Product $product the product to use to retrive translation
      * @param string      $slug    the language slug
      *
      * @return \WC_Product product translation or same product if translaion not found
@@ -98,13 +98,13 @@ final class Utilities
     }
 
     /**
-     * Get polylang langauge entity
+     * Get polylang language entity
      *
      * @global \Polylang $polylang
      *
      * @param string $slug the language slug
      *
-     * @return \PLL_Language|false language entity in success , false otherwise
+     * @return \PLL_Language|false language entity on success , false otherwise
      */
     public static function getLanguageEntity($slug)
     {
@@ -127,7 +127,7 @@ final class Utilities
      * @global \Polylang $polylang
      *
      * @param integer $ID             term id
-     * @param boolean $excludeDefault ture to exclude defualt language
+     * @param boolean $excludeDefault true to exclude default language
      *
      * @return array associative array with language code as key and ID of translations
      *               as value.
@@ -199,6 +199,26 @@ final class Utilities
         } else {
             return $result;
         }
+    }
+
+    /**
+     * Check WooCommerce version
+     *
+     * Check if you are running a specified WooCommerce version (or higher)
+     *
+     * @param string    $version    Version to check agains. (Default: 2.6)
+     *
+     * @return boolean  true if running version is equal or higher, false otherwise
+     */
+    public static function woocommerceVersionCheck( $version = '2.6' ) {
+
+        global $woocommerce;
+
+        if( version_compare( $woocommerce->version, $version, ">=" ) ) {
+            return true;
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
Fixed shipment methods translation and added support for WooCommerce 2.6.
Note: Shipping Class translation is disabled with WC2.6. This is due to Shipping Class translation is not supported after WooCommerce 2.6. WooCommerce change the Shipping Class interface and is no longer using the same actions and filters as WordPress. Therefore Polylan can't display the languages columns and metabox for custom post types and taxonomies.

I have also, corrected some typos in the code documentation, and improve the english text (user instructions) and string formatting (remove leading space in some metas) in the Meta List settings screen in the backend. This has nothing to do with "shipping" but felt right doing it.