### PR TITLE
Product type fix

### DIFF
--- a/src/Hyyan/WPI/Product/Meta.php
+++ b/src/Hyyan/WPI/Product/Meta.php
@@ -36,9 +36,9 @@ class Meta
     }
 
     /**
-     * Sync porduct meta.
+     * Sync product meta.
      *
-     * @return false if the current post type is not "porduct"
+     * @return false if the current post type is not "product"
      */
     public function syncProductsMeta()
     {
@@ -59,11 +59,11 @@ class Meta
          * Disable editing product meta for translation
          *
          * if the "post" is defined in $_GET then we should check if the current
-         * porduct has a translation and it is the same as the default translation
-         * lang defined in polylang then porduct meta editing must by enabled
+         * product has a translation and it is the same as the default translation
+         * lang defined in polylang then product meta editing must by enabled
          *
          * if the "new_lang" is defined or if the current page is the "edit"
-         * page then porduct meta editing must by disabled
+         * page then product meta editing must by disabled
          */
 
         if (isset($_GET['post'])) {
@@ -212,7 +212,7 @@ class Meta
     /**
      * Add the Fields Locker script.
      *
-     * The script will disable editing of some porduct metas for product
+     * The script will disable editing of some product metas for product
      * translation
      *
      * @return bool false if the fields locker feature is disabled
@@ -256,14 +256,14 @@ class Meta
     }
 
     /**
-     * Sync the porduct select list.
+     * Sync the product select list.
      *
      * @param int $ID product type
      */
     protected function syncSelectedproductType($ID = null)
     {
         /*
-         * First we add save_post action to save the porduct type
+         * First we add save_post action to save the product type
          * as post meta
          *
          * This is step is important so we can get the right product type

--- a/src/Hyyan/WPI/Product/Meta.php
+++ b/src/Hyyan/WPI/Product/Meta.php
@@ -269,7 +269,7 @@ class Meta
          * This is step is important so we can get the right product type
          */
         add_action('save_post', function ($_ID) {
-            $product = get_product($_ID);
+            $product = wc_get_product($_ID);    // get_product soft deprecated for wc_get_product
             if ($product && !isset($_GET['from_post'])) {
                 $type = $product->product_type;
                 update_post_meta($_ID, '_translation_porduct_type', $type);

--- a/src/Hyyan/WPI/Product/Meta.php
+++ b/src/Hyyan/WPI/Product/Meta.php
@@ -73,6 +73,10 @@ class Meta
             $disable = isset($_GET['new_lang']) && (esc_attr($_GET['new_lang']) != pll_default_language()) ?
                     true : false;
             $ID = isset($_GET['from_post']) ? absint($_GET['from_post']) : false;
+            
+            // Add the '_translation_porduct_type' meta, for the case where
+            // the product was created before plugin acivation.
+            $this->addProductTypeMeta($ID);
         }
 
         // disable fields edit for translation
@@ -84,6 +88,26 @@ class Meta
 
         /* sync selected product type */
         $this->syncSelectedproductType($ID);
+    }
+    
+    /**
+     * Add product type meta to products created before plugin activation.
+     *
+     * @param int $ID Id of the product in the default language
+     */
+    public function add_product_type_meta($ID)
+    {
+        if ($ID) {
+            $meta = get_post_meta($ID, '_translation_porduct_type');
+
+            if (empty($meta)) {
+                $product = wc_get_product($ID);
+                if ($product) {
+                    update_post_meta($ID, '_translation_porduct_type', $product->product_type);
+                }
+            }
+
+        }
     }
 
     /**

--- a/src/Hyyan/WPI/Product/Meta.php
+++ b/src/Hyyan/WPI/Product/Meta.php
@@ -95,7 +95,7 @@ class Meta
      *
      * @param int $ID Id of the product in the default language
      */
-    public function add_product_type_meta($ID)
+    public function addProductTypeMeta($ID)
     {
         if ($ID) {
             $meta = get_post_meta($ID, '_translation_porduct_type');


### PR DESCRIPTION
- Add _translation_porduct_type meta to products created before plugin activation
- Replace get_product soft deprecated for wc_get_product
- Correct "porduct" typo

Note/ToDo: __translation_porduct_type_ has a typo that was deliberately not corrected. Correcting it was result in brake product synchronization for products already translated in the BD.
To correct this we could enhance the new class method addProductTypeMeta() with a switch/case implementation

case "typo: replaces with correct meta name and use existing value
case "not found": add meta
case "found": do nothing

Let me know if you want me to implement this?