### PR TITLE
Fix variable products (non-taxonomies) attributes sync

### DIFF
--- a/src/Hyyan/WPI/Product/Variation.php
+++ b/src/Hyyan/WPI/Product/Variation.php
@@ -250,6 +250,8 @@ class Variation
                         if ($term) {
                             $lang = isset($_GET['new_lang']) ? esc_attr($_GET['new_lang']) : pll_get_post_language($this->to->id);
                             $translated[] = get_term_by('id', pll_get_term($term->term_id, $lang), $tax)->slug;
+                        } else {
+                            $translated[] = $termSlug;
                         }
                     }
                     $metas[$key] = $translated;


### PR DESCRIPTION
Custom attributes in product variations were not sync. Non-taxonomy attributes are not managed by Polylang, therefore no translation is found and the attribute would not be copied acrss to the variation translations.