### PR TITLE
Fix error on non-product post save

### DIFF
--- a/src/Hyyan/WPI/Product/Meta.php
+++ b/src/Hyyan/WPI/Product/Meta.php
@@ -43,6 +43,12 @@ class Meta
     public function syncProductsMeta()
     {
 
+        $currentScreen = get_current_screen();
+
+        if ($currentScreen->post_type !== 'product') {
+            return false;
+        }
+
         // sync product meta with polylang
         add_filter('pll_copy_post_metas', array(__CLASS__, 'getProductMetaToCopy'));
         // Shipping Class translation is not supported after WooCommerce 2.6 but it is
@@ -50,12 +56,6 @@ class Meta
         // copy the Shipping Class meta. We need to take care of it.
         if (Utilities::woocommerceVersionCheck('2.6')) { 
             add_action('wp_insert_post', array($this, 'syncShippingClass'), 10, 3);
-        }
-
-        $currentScreen = get_current_screen();
-
-        if ($currentScreen->post_type !== 'product') {
-            return false;
         }
 
         $ID = false;

--- a/src/Hyyan/WPI/Product/Variable.php
+++ b/src/Hyyan/WPI/Product/Variable.php
@@ -61,7 +61,7 @@ class Variable
         }
 
         global $pagenow;
-        if (!in_array($pagenow, array('post.php', 'post-new.php'))) {
+        if (!in_array($pagenow, array('post.php', 'post-new.php')) || get_post_type($ID) !== 'product') {
             return false;
         }
 
@@ -179,7 +179,7 @@ class Variable
     public function syncDefaultAttributes($post_id, $post, $update)
     {
         // Don't sync if not in the admin backend nor on autosave
-        if (!is_admin() &&  defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        if (!is_admin() &&  defined('DOING_AUTOSAVE') && DOING_AUTOSAVE || get_post_type($post_id) !== 'product') {
             return;
         }
 


### PR DESCRIPTION
Hi!

I'm getting 502 error on post save (locally) if I'm trying to save any other post type than products. Saving terms or products worked fine.

WP: 4.6.1
WC: 2.6.7
Polylang: 2.0.7
Woo-Poly-Integration: 0.28

I traced the problem to Product.php that has code that is run in every post type. I made a subtle changes to Meta.php and Variable.php that will return if the post type is not product. Please, check this out and tell me if this is causing some troubles that I didn't see.