### PR TITLE
Woocommerce 3.0 fix

### DIFF
--- a/src/Hyyan/WPI/Product/Stock.php
+++ b/src/Hyyan/WPI/Product/Stock.php
@@ -87,7 +87,7 @@ class Stock
      * @param array  $item   the order data
      * @param string $action STOCK_REDUCE_ACTION | STOCK_INCREASE_ACTION
      */
-    protected function change(array $item, $action = self::STOCK_REDUCE_ACTION)
+    protected function change($item, $action = self::STOCK_REDUCE_ACTION)
     {
         $productID = $item['product_id'];
         $productObject = wc_get_product($productID);


### PR DESCRIPTION
With new release I got this error when I submit order.
```
  Uncaught TypeError: Argument 1 passed to Hyyan\WPI\Product\Stock::change() must be of the type array, object given
```