### PR TITLE
Email Translations fixes #140, fixes #142, fixes #143, fixes #89, fixes #70

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+Thanks for contributing&mdash;you rock!
+
+# Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* See if your issue has been discussed (or even fixed) earlier. You can [search for existing issues](../../../issues?q=is%3Aissue).
+* Assuming it does not already exist, [create a new issue](../../../issues/new).
+  * Clearly describe the issue. In case you want to report a bug, include steps to reproduce it.
+
+* Fork the repository on GitHub.
+
+# Making Changes
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the `master` branch.
+  * Only target release branches if you are certain your fix must be on that branch.
+  * To quickly create a topic branch based on the `master` branch:
+    * `git checkout -b issue/%YOUR-ISSUE-NUMBER%_%DESCRIPTIVE-TITLE% master`
+    * a good example is `issue/123_typo_in_readme`
+* Make commits of logical units.
+* Make sure your commit messages are helpful.
+
+# Submitting Changes
+
+* Push your changes to the according topic branch in your fork of the repository.
+* [Create a pull request](../../../compare) to the original repository.
+* Wait for feedback. Pull requests get reviewed on a regular basis.
+
+# License
+
+By contributing code, you grant its use under the [MIT](../LICENSE).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for contributing&mdash;you rock!
+
+Please note:
+- These comments won't show up when you submit the issue.
+- This is free software supported by volunteers in their spare time.  Please help us by making your issue report as clear and simple as possible.
+If reporting a problem please make sure you confirm the following points so we can reproduce and fix your problem as quickly as possible:
+-->
+
+#### Version Information
+* PHP: 
+* WordPress: 
+* WooCommerce: 
+* Polylang: 
+* Hyyan WooCommerce Polylang Integration: 
+* Browser: 
+
+#### Can you reproduce this issue on default Wordpress theme (eg Storefront)?
+
+#### Can you reproduce this issue when all other plugins are disabled except WooCommerce, Polylang and Hyyan WooCommerce Polylang Integration?
+
+#### Steps to Reproduce
+1. 
+1. 
+1. 
+
+#### What I Expected
+
+
+
+#### What Happened Instead
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,11 @@ Please note:
 If reporting a problem please make sure you confirm the following points so we can reproduce and fix your problem as quickly as possible:
 -->
 
-#### Version Information
+#### Can you reproduce this issue on default Wordpress theme (eg Storefront)?
+
+#### Can you reproduce this issue when all other plugins are disabled except WooCommerce, Polylang and Hyyan WooCommerce Polylang Integration?
+
+#### What product versions and settings are you using when this issue occurs?
 * PHP: 
 * WordPress: 
 * WooCommerce: 
@@ -15,9 +19,6 @@ If reporting a problem please make sure you confirm the following points so we c
 * Hyyan WooCommerce Polylang Integration: 
 * Browser: 
 
-#### Can you reproduce this issue on default Wordpress theme (eg Storefront)?
-
-#### Can you reproduce this issue when all other plugins are disabled except WooCommerce, Polylang and Hyyan WooCommerce Polylang Integration?
 
 #### Steps to Reproduce
 1. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thanks for contributing&mdash;you rock!
+
+- Please make sure your changes respect the WordPress Coding Standards:
+  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+- In case you introduced a new action or filter hook, please also include inline documentation:
+  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
+- Please create tests, if you can.
+-->
+
+This pull request fixes #.
+
+#### What's Included in This Pull Request
+
+* 
+* 
+* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ### 0.30.0
 
-* Fix adaptations for wooCommerce 3.0
-* Add settings Page link to plugins page
-* Allow variation description to be editable in translations
+* Fix #137 #131 #130 #110 adaptations for wooCommerce 3.0
+* Fix #136 Variable product stock sync issue where stock managed at parent level
+* Enh #132 Add settings Page link to plugins page
+* Fix #128 Allow variation description to be editable in translations
+* Fix #129 #138 Account page only shows orders in current language
+* Fix #112 Shipping Class are not sync for Product Variations
 
 ### 0.29.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.30.0
+
+* Fix adaptations for wooCommerce 3.0
+* Add settings Page link to plugins page
+* Allow variation description to be editable in translations
+
 ### 0.29.1
 
 * Improve Multisite compatibility 

--- a/__init__.php
+++ b/__init__.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * GitHub Plugin URI: hyyan/woo-poly-integration
  * License: MIT License
- * Version: 0.29.1
+ * Version: 0.30.0
  */
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -116,9 +116,12 @@ Just make sure to setup your permalinks , and every thing will be fine , I promi
 
 == 0.30.0 ==
 
-* Fix adaptations for wooCommerce 3.0
-* Add settings Page link to plugins page
-* Allow variation description to be editable in translations
+* Fix #137 #131 #130 #110 adaptations for wooCommerce 3.0
+* Fix #136 Variable product stock sync issue where stock managed at parent level
+* Enh #132 Add settings Page link to plugins page
+* Fix #128 Allow variation description to be editable in translations
+* Fix #129 #138 Account page only shows orders in current language
+* Fix #112 Shipping Class are not sync for Product Variations
 
 == 0.29.1 ==
 
@@ -253,6 +256,7 @@ woocommerce and polylang , please update immediately
 = 0.29.1 =
 The release includes important fixes and updates for latest version of 
 woocommerce and polylang , please update immediately 
+
 = 0.30.0 =
 The release includes important fixes and updates for latest version of 
 woocommerce and polylang , please update immediately 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Hyyan WooCommerce Polylang Integration===
-Contributors: hyyan, decarvalhoaa
-Tags: cms, commerce, e-commerce, e-shop, ecommerce, multilingual, products, shop, woocommerce, polylang ,bilingual, international, language, localization, multilanguage, multilingual, translate, translation
+Contributors: hyyan, decarvalhoaa, jonathanmoorebcsorg, leemon, harasse
+Tags: cms, commerce, e-commerce, e-shop, ecommerce, multilingual, products, shop, woocommerce, polylang, bilingual, international, language, localization, multilanguage, multilingual, translate, translation
 Requires at least: 3.8
-Tested up to: 4.7
-Stable tag: 0.29.1
+Tested up to: 4.7.4
+Stable tag: 0.30.0
 License: MIT
 License URI: https://github.com/hyyan/woo-poly-integration/blob/master/LICENSE
 
@@ -16,7 +16,7 @@ WooCommerce and Polylang.It makes products and store pages translatable, lets
 visitors switch languages and order products in their language. and all that from
 the same interface you love.
 
-> Please do not ask for support on wordpress forum anymore , it is becoming hard to me to follow issues on wordpress forum , Email and Github , if you want help just open new Github issue.
+> Please do not ask for support on wordpress forum anymore , it is becoming hard to me to follow issues on wordpress forum , Email and Github , if you want help just open new Github issue please.
 
 = Features  =
 
@@ -113,6 +113,12 @@ Just make sure to setup your permalinks , and every thing will be fine , I promi
 6. Control plugin features from its admin page 
 
 == Changelog ==
+
+== 0.30.0 ==
+
+* Fix adaptations for wooCommerce 3.0
+* Add settings Page link to plugins page
+* Allow variation description to be editable in translations
 
 == 0.29.1 ==
 
@@ -245,5 +251,8 @@ The release includes important fixes and updates for latest version of
 woocommerce and polylang , please update immediately 
 
 = 0.29.1 =
+The release includes important fixes and updates for latest version of 
+woocommerce and polylang , please update immediately 
+= 0.30.0 =
 The release includes important fixes and updates for latest version of 
 woocommerce and polylang , please update immediately 

--- a/src/Hyyan/WPI/Admin/Settings.php
+++ b/src/Hyyan/WPI/Admin/Settings.php
@@ -102,10 +102,11 @@ class Settings extends \WeDevs_Settings_API
     {
         $options = get_option($section);
 
-        if (isset($options[$option])) {
-            return $options[$option];
-        }
-
-        return $default;
+        if (!empty($options[$option]))  // equivalent to: isset($options[$option]) && $options[$option]
+            return $options[$option];   // when all settings are disabled
+        elseif (isset($options[$option])) 
+            return array();
+        else
+            return $default;
     }
 }

--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -91,7 +91,7 @@ class Cart
         // By default, returns the same input
         $cart_item_data_translation = $cart_item_data;
 
-        switch ( $cart_item_data->product_type ) {
+        switch ( $cart_item_data->get_type() ) {
             case 'variation':
                 $variation_translation   = $this->getVariationTranslation( $cart_variation_id );
                 $cart_item_data_translation = $variation_translation ? $variation_translation : $cart_item_data_translation;
@@ -337,7 +337,10 @@ class Cart
 					}
 
 					// Get valid value from variation
-					$valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : '';
+//change proposed by @theleemon
+$variation_data = wc_get_product_variation_attributes($variation->get_id());
+$valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : '';
+					//$valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : '';
 
 					// Allow if valid or show error.
 					if ( '' === $valid_value || $valid_value === $value) {

--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -420,15 +420,8 @@ $valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : 
 
         // Get parent product translation id for the given language
         $variation   = wc_get_product($variation_id);
-				if (Utilities::woocommerceVersionCheck('3.0')) 
-				{
-        $parent      = $variation ? wc_get_product($variation->get_parent_id()) : null;
-				}
-				else
-				{
-					$parent      = $variation ? $variation->parent : null;
-				}
-        $_product_id = $parent ? pll_get_post($parent->get_id(), $lang) : null;
+				$parentid = Utilities::get_variation_parentid($variation);
+				$_product_id = pll_get_post($parentid, $lang);
 
         // Get variation translation using the duplication metadata value
         $meta = get_post_meta($variation_id, Variation::DUPLICATE_KEY, true);

--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -66,8 +66,8 @@ class Cart
         foreach (WC()->cart->get_cart() as $values) {
             $product = $values['data'];
 
-            if (in_array($product->id, $IDS)) {
-                $result = $product->id;
+            if (in_array($product->get_id(), $IDS)) {
+                $result = $product->get_id();
                 break;
             }
         }
@@ -265,7 +265,8 @@ class Cart
 
         // If no variation ID is set, attempt to get a variation ID from posted attributes.
         if (empty($variation_id)) {
-            $variation_id = $adding_to_cart->get_matching_variation(wp_unslash($_POST));
+            $data_store   = WC_Data_Store::load('product');
+			$variation_id = $data_store->find_matching_product_variation($adding_to_cart, wp_unslash($_POST));
         }
 
         /**
@@ -291,76 +292,90 @@ class Cart
          * End of custom code.
          */
 
-        //$variation = wc_get_product( $variation_id );
+        // Validate the attributes.
+		try {
+			if (empty($variation_id)) {
+				throw new Exception(__('Please choose product options&hellip;', 'woocommerce') );
+			}
 
-        // Verify all attributes
-        foreach ($attributes as $attribute) {
-            if (!$attribute['is_variation']) {
-                    continue;
-            }
+			$variation_data = wc_get_product_variation_attributes($variation_id);
 
-            $taxonomy = 'attribute_' . sanitize_title($attribute['name']);
+			foreach ($attributes as $attribute) {
+				if (!$attribute['is_variation']) {
+					continue;
+				}
 
-            if (isset($_REQUEST[$taxonomy])) {
-                // Get value from post data
-                if ($attribute['is_taxonomy']) {
-                    // Don't use wc_clean as it destroys sanitized characters
-                    $value = sanitize_title(stripslashes($_REQUEST[$taxonomy]));
+				$taxonomy = 'attribute_' . sanitize_title($attribute['name']);
 
-                    /**
-                    * Custom code to check if a translation of the product is already in the cart,
-                    * and in that case, replace the variation attribute being added to the cart by
-                    * the respective translation in the language of the product already in the cart
-                    * NOTE: The product_id is filtered by $this->add_to_cart() and holds the id of
-                    * the product translation, if one exists in the cart.
-                    */
-                    if ($product_id != absint($_REQUEST['add-to-cart'])) {
-                        // Get the translation of the term
-                        $term  = get_term_by('slug', $value, $attribute['name']);
-                        $_term = get_term_by('id', pll_get_term(absint($term->term_id), $lang), $attribute['name']);
-
-                        if ($_term) {
-                            $value = $_term->slug;
+				if (isset($_REQUEST[$taxonomy])) {
+					// Get value from post data
+					if ($attribute['is_taxonomy']) {
+						// Don't use wc_clean as it destroys sanitized characters
+						$value = sanitize_title(stripslashes($_REQUEST[$taxonomy]));
+                        
+                        /**
+                        * Custom code to check if a translation of the product is already in the cart,
+                        * and in that case, replace the variation attribute being added to the cart by
+                        * the respective translation in the language of the product already in the cart
+                        * NOTE: The product_id is filtered by $this->add_to_cart() and holds the id of
+                        * the product translation, if one exists in the cart.
+                        */
+                        if ($product_id != absint($_REQUEST['add-to-cart'])) {
+                            // Get the translation of the term
+                            $term  = get_term_by('slug', $value, $attribute['name']);
+                            $_term = get_term_by('id', pll_get_term(absint($term->term_id), $lang), $attribute['name']);
+    
+                            if ($_term) {
+                                $value = $_term->slug;
+                            }
                         }
-                    }
-                    /**
-                    * End of custom code.
-                    */
-                } else {
-                    $value = wc_clean(stripslashes($_REQUEST[$taxonomy]));
-                }
+                        /**
+                        * End of custom code.
+                        */
+					} else {
+						$value = wc_clean(stripslashes($_REQUEST[$taxonomy]));
+					}
 
-                // Get valid value from variation
-                $valid_value = isset($variation->variation_data[$taxonomy]) ? $variation->variation_data[$taxonomy] : '';
+					// Get valid value from variation
+					$valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : '';
 
-                // Allow if valid
-                if ('' === $valid_value || $valid_value === $value) {
-                    $variations[$taxonomy] = $value;
-                    continue;
-                }
-            } else {
-                $missing_attributes[] = wc_attribute_label($attribute['name']);
-            }
-        }
+					// Allow if valid or show error.
+					if ( '' === $valid_value || $valid_value === $value) {
+						$variations[$taxonomy] = $value;
+					} else {
+						throw new Exception(sprintf(__('Invalid value posted for %s', 'woocommerce'), wc_attribute_label($attribute['name'])));
+					}
+				} else {
+					$missing_attributes[] = wc_attribute_label($attribute['name']);
+				}
+			}
+			if (!empty($missing_attributes)) {
+				throw new Exception(sprintf(_n('%s is a required field', '%s are required fields', sizeof($missing_attributes), 'woocommerce'), wc_format_list_of_items($missing_attributes)));
+			}
+		} catch (Exception $e) {
+			wc_add_notice($e->getMessage(), 'error');
+            //return false;
+            /**
+             * Custom code: We are doing an action, therefore no return needed. Instead we need to
+             * set $passed_validation to false, to ensure the product is not added to the card.
+             */
+            add_filter('woocommerce_add_to_cart_validation', '__return_false');
+		}
 
-        if (!empty($missing_attributes)) {
-            wc_add_notice(sprintf(_n('%s is a required field', '%s are required fields', sizeof($missing_attributes), 'woocommerce'), wc_format_list_of_items($missing_attributes)), 'error');
-        } elseif (empty($variation_id)) {
-            wc_add_notice(__('Please choose product options&hellip;', 'woocommerce'), 'error');
-        } else {
-            // Add to cart validation
-            $passed_validation 	= apply_filters('woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations);
+		// Add to cart validation
+		$passed_validation 	= apply_filters('woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations);
 
-            if ($passed_validation && WC()->cart->add_to_cart($product_id, $quantity, $variation_id, $variations) !== false) {
-                wc_add_to_cart_message(array($product_id => $quantity), true);
+		if ($passed_validation && WC()->cart->add_to_cart($product_id, $quantity, $variation_id, $variations) !== false) {
+			wc_add_to_cart_message(array($product_id => $quantity), true);
+			//return true;
+            /**
+             * Custom code: We are doing an action, therefore no return needed. Intead we need to
+             * set $was_added_to_cart to true to trigger the optional redirect
+             */
+            $was_added_to_cart = true;
+		}
 
-                //return true; Doing an action, no return needed but we need to set $was_added_to_cart to trigger the redirect
-                $was_added_to_cart = true;
-            } else {
-                $was_added_to_cart = false;
-            }
-        }
-        //return false; Doing an action, no return needed but we need to set $was_added_to_cart to trigger the redirect
+		//return false; We are doing an action, therefore no return needed. but we need to set $was_added_to_cart to trigger the redirect
         // End: From add_to_cart_handler_variable( $product_id )
 
         /**
@@ -401,8 +416,8 @@ class Cart
 
         // Get parent product translation id for the given language
         $variation   = wc_get_product($variation_id);
-        $parent      = $variation ? $variation->parent : null;
-        $_product_id = $parent ? pll_get_post($parent->id, $lang) : null;
+        $parent      = $variation ? wc_get_product($variation->get_parent_id()) : null;
+        $_product_id = $parent ? pll_get_post($parent->get_id(), $lang) : null;
 
         // Get variation translation using the duplication metadata value
         $meta = get_post_meta($variation_id, Variation::DUPLICATE_KEY, true);

--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -11,6 +11,7 @@
 namespace Hyyan\WPI;
 
 use Hyyan\WPI\Product\Variation;
+use Hyyan\WPI\Utilities;
 
 /**
  * Cart.
@@ -284,7 +285,7 @@ class Cart
 
             // Get the respective variation in the language of the product in the cart
             $variation    = $this->getVariationTranslation($variation_id, $lang);
-            $variation_id = $variation->variation_id;
+            $variation_id = $variation->get_id();
         } else {
             $variation = wc_get_product($variation_id);
         }
@@ -419,7 +420,14 @@ $valid_value = isset($variation_data[$taxonomy]) ? $variation_data[$taxonomy] : 
 
         // Get parent product translation id for the given language
         $variation   = wc_get_product($variation_id);
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         $parent      = $variation ? wc_get_product($variation->get_parent_id()) : null;
+				}
+				else
+				{
+					$parent      = $variation ? $variation->parent : null;
+				}
         $_product_id = $parent ? pll_get_post($parent->get_id(), $lang) : null;
 
         // Get variation translation using the duplication metadata value

--- a/src/Hyyan/WPI/Coupon.php
+++ b/src/Hyyan/WPI/Coupon.php
@@ -69,10 +69,10 @@ class Coupon
             }
         }
 
-        $coupon->product_ids = $productIDS;
-        $coupon->exclude_product_ids = $excludeProductIDS;
-        $coupon->product_categories = $productCategoriesIDS;
-        $coupon->exclude_product_categories = $excludeProductCategoriesIDS;
+				$coupon->set_product_ids( $productIDS );
+				$coupon->set_excluded_product_ids( $excludeProductIDS );
+				$coupon->set_product_categories( $productCategoriesIDS );
+				$coupon->set_excluded_product_categories( $excludeProductCategoriesIDS );
 
         return $coupon;
     }
@@ -89,7 +89,7 @@ class Coupon
         $result = array($ID);
         $product = wc_get_product($ID);
 
-        if ($product && $product->product_type === 'variation') {
+        if ($product && $product->get_type() === 'variation') {
             $IDS = Product\Variation::getRelatedVariation($ID, true);
             if (is_array($IDS)) {
                 $result = array_merge($result, $IDS);

--- a/src/Hyyan/WPI/Coupon.php
+++ b/src/Hyyan/WPI/Coupon.php
@@ -12,6 +12,7 @@ namespace Hyyan\WPI;
 
 use Hyyan\WPI\Admin\Settings;
 use Hyyan\WPI\Admin\Features;
+use Hyyan\WPI\Utilities;
 
 /**
  * Coupon.
@@ -41,6 +42,9 @@ class Coupon
      */
     public function couponLoaded(\WC_Coupon $coupon)
     {
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+			  
         $productIDS = array();
         $excludeProductIDS = array();
         $productCategoriesIDS = array();
@@ -76,7 +80,51 @@ class Coupon
 
         return $coupon;
     }
+				else
+				{
+					return $this->couponLoadedOld($coupon);
+				}
+		}
 
+    /**
+     * Extend the coupon to include porducts translations.
+     *
+     * @param \WC_Coupon $coupon
+     *
+     * @return \WC_Coupon
+     */
+    public function couponLoadedOld(\WC_Coupon $coupon)
+    {
+        $productIDS = array();
+        $excludeProductIDS = array();
+        $productCategoriesIDS = array();
+        $excludeProductCategoriesIDS = array();
+        foreach ($coupon->product_ids as $id) {
+            foreach ($this->getProductPostTranslationIDS($id) as $_id) {
+                $productIDS[] = $_id;
+            }
+        }
+        foreach ($coupon->exclude_product_ids as $id) {
+            foreach ($this->getProductPostTranslationIDS($id) as $_id) {
+                $excludeProductIDS[] = $_id;
+            }
+        }
+        foreach ($coupon->product_categories as $id) {
+            foreach ($this->getProductTermTranslationIDS($id) as $_id) {
+                $productCategoriesIDS[] = $_id;
+            }
+        }
+        foreach ($coupon->exclude_product_categories as $id) {
+            foreach ($this->getProductTermTranslationIDS($id) as $_id) {
+                $excludeProductCategoriesIDS[] = $_id;
+            }
+        }
+        $coupon->product_ids = $productIDS;
+        $coupon->exclude_product_ids = $excludeProductIDS;
+        $coupon->product_categories = $productCategoriesIDS;
+        $coupon->exclude_product_categories = $excludeProductCategoriesIDS;
+        return $coupon;
+    }
     /**
      * Get array of product translations IDS.
      *

--- a/src/Hyyan/WPI/Coupon.php
+++ b/src/Hyyan/WPI/Coupon.php
@@ -46,24 +46,24 @@ class Coupon
         $productCategoriesIDS = array();
         $excludeProductCategoriesIDS = array();
 
-        foreach ($coupon->product_ids as $id) {
+        foreach ($coupon->get_product_ids() as $id) {
             foreach ($this->getProductPostTranslationIDS($id) as $_id) {
                 $productIDS[] = $_id;
             }
         }
-        foreach ($coupon->exclude_product_ids as $id) {
+        foreach ($coupon->get_excluded_product_ids() as $id) {
             foreach ($this->getProductPostTranslationIDS($id) as $_id) {
                 $excludeProductIDS[] = $_id;
             }
         }
 
-        foreach ($coupon->product_categories as $id) {
+        foreach ($coupon->get_product_categories() as $id) {
             foreach ($this->getProductTermTranslationIDS($id) as $_id) {
                 $productCategoriesIDS[] = $_id;
             }
         }
 
-        foreach ($coupon->exclude_product_categories as $id) {
+        foreach ($coupon->get_excluded_product_categories() as $id) {
             foreach ($this->getProductTermTranslationIDS($id) as $_id) {
                 $excludeProductCategoriesIDS[] = $_id;
             }

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -464,16 +464,7 @@ class Emails
             return $string; // Returns the original $string on error (no order to get language from)
         }
 
-        // Get order language
-				if (Utilities::woocommerceVersionCheck('3.0')) 
-				{
-        $order_language = pll_get_post_language($order->get_id(), 'locale');
-				}
-				else
-				{
-	        $order_language = pll_get_post_language($order->id, 'locale');
-				}
-
+				$order_language = pll_get_post_language(Utilities::get_orderid($order), 'locale');
         if ($order_language == '') {
             $order_language = pll_current_language('locale');
         }

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -12,6 +12,7 @@ namespace Hyyan\WPI;
 
 use Hyyan\WPI\Admin\Settings;
 use Hyyan\WPI\Admin\Features;
+use Hyyan\WPI\Utilities;
 
 /**
  * Emails.
@@ -464,7 +465,14 @@ class Emails
         }
 
         // Get order language
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         $order_language = pll_get_post_language($order->get_id(), 'locale');
+				}
+				else
+				{
+	        $order_language = pll_get_post_language($order->id, 'locale');
+				}
 
         if ($order_language == '') {
             $order_language = pll_current_language('locale');
@@ -494,9 +502,17 @@ class Emails
         $find['order-number'] = '{order_number}';
         $find['site_title'] = '{site_title}';
 
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         $replace['order-date'] = date_i18n(wc_date_format(), strtotime($order->get_date_created()));
+  			}
+				else
+				{
+					$replace['order-date'] = date_i18n(wc_date_format(), strtotime($order->order_date));
+				}
         $replace['order-number'] = $order->get_order_number();
         $replace['site_title'] = get_bloginfo('name');
+
 
         $string = str_replace($find, $replace, $string);
 

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -464,7 +464,7 @@ class Emails
         }
 
         // Get order language
-        $order_language = pll_get_post_language($order->id, 'locale');
+        $order_language = pll_get_post_language($order->get_id(), 'locale');
 
         if ($order_language == '') {
             $order_language = pll_current_language('locale');
@@ -494,7 +494,7 @@ class Emails
         $find['order-number'] = '{order_number}';
         $find['site_title'] = '{site_title}';
 
-        $replace['order-date'] = date_i18n(wc_date_format(), strtotime($order->order_date));
+        $replace['order-date'] = date_i18n(wc_date_format(), strtotime($order->get_date_created()));
         $replace['order-number'] = $order->get_order_number();
         $replace['site_title'] = get_bloginfo('name');
 

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -44,6 +44,8 @@ class Emails
             // new order
             add_filter('woocommerce_email_subject_new_order', array($this, 'translateEmailSubjectNewOrder'), 10, 2);
             add_filter('woocommerce_email_heading_new_order', array($this, 'translateEmailHeadingNewOrder'), 10, 2);
+            add_filter('woocommerce_email_recipient_new_order', array($this, 'translateEmailRecipientNewOrder'), 10, 2);
+
             // processing order
             add_filter('woocommerce_email_subject_customer_processing_order', array($this, 'translateEmailSubjectCustomerProcessingOrder'), 10, 2);
             add_filter('woocommerce_email_heading_customer_processing_order', array($this, 'translateEmailHeadingCustomerProcessingOrder'), 10, 2);
@@ -68,6 +70,25 @@ class Emails
             // reset password
             add_filter('woocommerce_email_subject_customer_reset_password', array($this, 'translateEmailSubjectCustomerResetPassword'), 10, 2);
             add_filter('woocommerce_email_heading_customer_reset_password', array($this, 'translateEmailHeadingCustomerResetPassword'), 10, 2);
+
+						// On Hold Order
+            add_filter('woocommerce_email_subject_customer_on_hold_order', array($this, 'translateEmailSubjectCustomerOnHoldOrder'), 10, 2);
+            add_filter('woocommerce_email_heading_customer_on_hold_order', array($this, 'translateEmailHeadingCustomerOnHoldOrder'), 10, 2);
+
+						// Cancelled Order
+            add_filter('woocommerce_email_subject_cancelled_order', array($this, 'translateEmailSubjectCancelOrder'), 10, 2);
+            add_filter('woocommerce_email_heading_cancelled_order', array($this, 'translateEmailHeadingCancelOrder'), 10, 2);
+            add_filter('woocommerce_email_recipient_cancelled_order', array($this, 'translateEmailRecipientCancelOrder'), 10, 2);
+
+						// Failed Order
+            add_filter('woocommerce_email_subject_failed_order', array($this, 'translateEmailSubjectFailedOrder'), 10, 2);
+            add_filter('woocommerce_email_heading_failed_order', array($this, 'translateEmailHeadingFailedOrder'), 10, 2);
+            add_filter('woocommerce_email_recipient_failed_order', array($this, 'translateEmailRecipientFailedOrder'), 10, 2);
+						
+						// strings for all emails
+						add_filter('woocommerce_email_footer_text', array($this, 'translateCommonString'));
+						add_filter('woocommerce_email_from_address', array($this, 'translateCommonString'));
+						add_filter('woocommerce_email_from_name', array($this, 'translateCommonString'));
         }
     }
 
@@ -86,6 +107,9 @@ class Emails
             'customer_completed_order',
             'customer_new_account',
             'customer_reset_password',
+            'customer_on_hold_order',
+            'cancelled_order',
+						'failed_order',
         );
 
         $this->default_settings = array(
@@ -111,6 +135,12 @@ class Emails
             'customer_new_account_heading' => __('Welcome to {site_title}', 'woocommerce'),
             'customer_reset_password_subject' => __('Password Reset for {site_title}', 'woocommerce'),
             'customer_reset_password_heading' => __('Password Reset Instructions', 'woocommerce'),
+            'customer_on_hold_order_subject' => __('Your {site_title} order receipt from {order_date}', 'woocommerce'),
+            'customer_on_hold_order_heading' => __('Thank you for your order', 'woocommerce'),
+            'cancelled_order_subject' => __('[{site_title}] Cancelled order ({order_number})', 'woocommerce'),
+            'cancelled_order_heading' => __('Cancelled order', 'woocommerce'),
+            'failed_order_subject' => __('[{site_title}] Failed order ({order_number})', 'woocommerce'),
+            'failed_order_heading' => __('Failed order', 'woocommerce'),
         );
 
         // Register strings for translation and hook filters
@@ -134,16 +164,27 @@ class Emails
                     break;
 
                 case 'new_order':
+                case 'cancelled_order':
+								case 'failed_order': 
                 case 'customer_processing_order':
                 case 'customer_note':
                 case 'customer_new_account':
                 case 'customer_reset_password':
+								case 'customer_on_hold_order':
                 default:
                     // Register strings
                     $this->registerString($email);
                     break;
             }
         }
+				
+				//Register global email strings for translation
+				$this->registerCommonString ( 'woocommerce_email_footer_text', 
+						sprintf( __( '%s - Powered by WooCommerce', 'woocommerce' ), get_bloginfo( 'name', 'display' ))
+						);
+				$this->registerCommonString ('woocommerce_email_from_name', esc_attr( get_bloginfo( 'name', 'display' )) );
+				$this->registerCommonString ('woocommerce_email_from_address', get_option( 'admin_email' ) );
+
     }
 
     /**
@@ -167,8 +208,181 @@ class Emails
                     pll_register_string('woocommerce_'.$email_type.'_subject'.$sufix, $settings['subject'.$sufix], __('Woocommerce Emails', 'woo-poly-integration'));
                     pll_register_string('woocommerce_'.$email_type.'_heading'.$sufix, $settings['heading'.$sufix], __('Woocommerce Emails', 'woo-poly-integration'));
                 }
+								//recipient applies to shop emails New, Cancel and Failed order types
+                if (isset($settings['recipient'.$sufix])) {
+                    pll_register_string('woocommerce_'.$email_type.'_recipient'.$sufix, $settings['recipient'.$sufix], __('Woocommerce Emails', 'woo-poly-integration'));
+                }
             }
         }
+    }
+
+    /**
+     * Register common strings for all wooCommerce emails for translation in Polylang
+     * Strings Translations table.
+     *
+     * Note: This function uses get_option to retrive the 
+     * string from the WooCommerce Admin Settings page. get_option will return false
+     * if the Admin user has not changed (nor saved) the default settings.
+		 * 
+     *
+     * @param string $email_type Email type
+     * @param string $sufix      Additional string variation, e.g. invoice paid vs invoice
+     */
+    public function registerCommonString($setting, $default = '')
+    {
+        if (function_exists('pll_register_string')) {
+            $value = get_option($setting);
+
+            if (!($value)) {
+							$value = $default;
+            }
+            if ($value) {
+							pll_register_string($setting, $value, __('Woocommerce Emails', 'woo-poly-integration'));
+						}
+        }
+    }
+		
+    /**
+     * Translate to the order language, the email subject of new order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateCommonString($email_string)
+    {
+        if (function_exists('pll_register_string')) {
+						$lang = pll_current_language('locale');
+						$trans = pll__($email_string);
+						if ($trans){
+							return $trans;
+						}
+						else{
+							return $email_string;
+						}
+				}
+    }
+
+
+    /**
+     * Translate to the order language, the email subject of processing order email notifications to the customer.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailSubjectCustomerOnHoldOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'subject', 'customer_on_hold_order');
+    }
+
+    /**
+     * Translate to the order language, the email heading of processing order email notifications to the customer.
+     *
+     * @param string   $heading Email heading in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated heading
+     */
+    public function translateEmailHeadingCustomerOnHoldOrder($heading, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($heading, $order, 'heading', 'customer_on_hold_order');
+    }
+
+ 
+
+    /**
+     * Translate to the order language, the email subject of Cancel order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailRecipientFailedOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'recipient', 'failed_order');
+    }
+		
+    /**
+     * Translate to the order language, the email subject of Failed order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailSubjectFailedOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'subject', 'failed_order');
+            }
+
+    /**
+     * Translate to the order language, the email heading of Failed order email notifications to the admin.
+     *
+     * @param string   $heading Email heading in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated heading
+     */
+    public function translateEmailHeadingFailedOrder($heading, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($heading, $order, 'heading', 'failed_order');
+        }
+
+    /**
+     * Translate to the order language, the email subject of Cancel order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailRecipientCancelOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'recipient', 'cancelled_order');
+    }
+		
+    /**
+     * Translate to the order language, the email subject of Cancel order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailSubjectCancelOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'subject', 'cancelled_order');
+    }
+
+    /**
+     * Translate to the order language, the email heading of Cancel order email notifications to the admin.
+     *
+     * @param string   $heading Email heading in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated heading
+     */
+    public function translateEmailHeadingCancelOrder($heading, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($heading, $order, 'heading', 'cancelled_order');
+    }
+
+
+    /**
+     * Translate to the order language, the email subject of Cancel order email notifications to the admin.
+     *
+     * @param string   $subject Email subject in default language
+     * @param WC_Order $order   Order object
+     *
+     * @return string Translated subject
+     */
+    public function translateEmailRecipientNewOrder($subject, $order)
+    {
+        return $this->translateEmailStringToOrderLanguage($subject, $order, 'recipient', 'new_order');
     }
 
     /**
@@ -460,13 +674,13 @@ class Emails
      */
     public function translateEmailStringToOrderLanguage($string, $order, $string_type, $email_type)
     {
-        if (empty($order)) {
-            return $string; // Returns the original $string on error (no order to get language from)
-        }
-
-				$order_language = pll_get_post_language(Utilities::get_orderid($order), 'locale');
+				//allow function to be called with no order to try to pick up pll locale for footer, from address and name
+				$order_language = ($order) ? pll_get_post_language(Utilities::get_orderid($order), 'locale') : '';
         if ($order_language == '') {
             $order_language = pll_current_language('locale');
+						if (!($order_language)){
+							return $string;
+						}
         }
 
         // Get setting used to register string in the Polylang strings translation table
@@ -486,6 +700,7 @@ class Emails
             $string = __($this->default_settings[$email_type.'_'.$string_type], 'woocommerce');
         }
 
+				if ($order) {
         $find = array();
         $replace = array();
 
@@ -506,7 +721,7 @@ class Emails
 
 
         $string = str_replace($find, $replace, $string);
-
+				}
         return $string;
     }
 

--- a/src/Hyyan/WPI/Gateways/GatewayBACS.php
+++ b/src/Hyyan/WPI/Gateways/GatewayBACS.php
@@ -52,16 +52,7 @@ class GatewayBACS extends \WC_Gateway_BACS
             if ($this->instructions) {
                 echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
             }
-						if (Utilities::woocommerceVersionCheck('3.0')) 
-						{
-							$order_id = $order->get_id();
-						}
-						else
-						{
-							$order_id = $order->id;
-						}
-            $this->bank_details($order_id);
-
+            $this->bank_details(Utilities::get_orderid($order));
         }
     }
 
@@ -83,7 +74,7 @@ class GatewayBACS extends \WC_Gateway_BACS
         $order = wc_get_order($order_id);
 
         // Get the order country and country $locale
-        $country = $order->get_billing_country();
+				$country = Utilities::get_billing_country($order);
         $locale = $this->get_country_locale();
 
         // Get sortcode label in the $locale array and use appropriate one

--- a/src/Hyyan/WPI/Gateways/GatewayBACS.php
+++ b/src/Hyyan/WPI/Gateways/GatewayBACS.php
@@ -9,6 +9,7 @@
  */
 
 namespace Hyyan\WPI\Gateways;
+use Hyyan\WPI\Utilities;
 
 /**
  * Gateways BACS.
@@ -47,11 +48,20 @@ class GatewayBACS extends \WC_Gateway_BACS
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if (!$sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status('on-hold')) {
+        if (!$sent_to_admin && 'bacs' === Utilities::get_payment_method($order) && $order->has_status('on-hold')) {
             if ($this->instructions) {
                 echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
             }
-            $this->bank_details($order->get_id());
+						if (Utilities::woocommerceVersionCheck('3.0')) 
+						{
+							$order_id = $order->get_id();
+						}
+						else
+						{
+							$order_id = $order->id;
+						}
+            $this->bank_details($order_id);
+
         }
     }
 

--- a/src/Hyyan/WPI/Gateways/GatewayBACS.php
+++ b/src/Hyyan/WPI/Gateways/GatewayBACS.php
@@ -47,11 +47,11 @@ class GatewayBACS extends \WC_Gateway_BACS
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if (!$sent_to_admin && 'bacs' === $order->payment_method && $order->has_status('on-hold')) {
+        if (!$sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status('on-hold')) {
             if ($this->instructions) {
                 echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
             }
-            $this->bank_details($order->id);
+            $this->bank_details($order->get_id());
         }
     }
 
@@ -73,7 +73,7 @@ class GatewayBACS extends \WC_Gateway_BACS
         $order = wc_get_order($order_id);
 
         // Get the order country and country $locale
-        $country = $order->billing_country;
+        $country = $order->get_billing_country();
         $locale = $this->get_country_locale();
 
         // Get sortcode label in the $locale array and use appropriate one

--- a/src/Hyyan/WPI/Gateways/GatewayCOD.php
+++ b/src/Hyyan/WPI/Gateways/GatewayCOD.php
@@ -47,7 +47,7 @@ class GatewayCOD extends \WC_Gateway_COD
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if ($this->instructions && !$sent_to_admin && 'cod' === $order->payment_method) {
+        if ($this->instructions && !$sent_to_admin && 'cod' === $order->get_payment_method()) {
             echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
         }
     }

--- a/src/Hyyan/WPI/Gateways/GatewayCOD.php
+++ b/src/Hyyan/WPI/Gateways/GatewayCOD.php
@@ -9,6 +9,7 @@
  */
 
 namespace Hyyan\WPI\Gateways;
+use Hyyan\WPI\Utilities;
 
 /**
  * Gateways Cash on Delivery.
@@ -47,7 +48,7 @@ class GatewayCOD extends \WC_Gateway_COD
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if ($this->instructions && !$sent_to_admin && 'cod' === $order->get_payment_method()) {
+        if ($this->instructions && !$sent_to_admin && 'cod' === Utilities::get_payment_method($order)) {
             echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
         }
     }

--- a/src/Hyyan/WPI/Gateways/GatewayCheque.php
+++ b/src/Hyyan/WPI/Gateways/GatewayCheque.php
@@ -47,7 +47,7 @@ class GatewayCheque extends \WC_Gateway_Cheque
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if ($this->instructions && !$sent_to_admin && 'cheque' === $order->payment_method && $order->has_status('on-hold')) {
+        if ($this->instructions && !$sent_to_admin && 'cheque' === $order->get_payment_method() && $order->has_status('on-hold')) {
             echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
         }
     }

--- a/src/Hyyan/WPI/Gateways/GatewayCheque.php
+++ b/src/Hyyan/WPI/Gateways/GatewayCheque.php
@@ -9,6 +9,7 @@
  */
 
 namespace Hyyan\WPI\Gateways;
+use Hyyan\WPI\Utilities;
 
 /**
  * Gateways Cheque.
@@ -47,7 +48,7 @@ class GatewayCheque extends \WC_Gateway_Cheque
      */
     public function email_instructions($order, $sent_to_admin, $plain_text = false)
     {
-        if ($this->instructions && !$sent_to_admin && 'cheque' === $order->get_payment_method() && $order->has_status('on-hold')) {
+        if ($this->instructions && !$sent_to_admin && 'cheque' === Utilities::get_payment_method($order) && $order->has_status('on-hold')) {
             echo wpautop(wptexturize(function_exists('pll__') ? pll__($this->instructions) : __($this->instructions, 'woocommerce'))).PHP_EOL;
         }
     }

--- a/src/Hyyan/WPI/Media.php
+++ b/src/Hyyan/WPI/Media.php
@@ -25,9 +25,19 @@ class Media
     public function __construct()
     {
         if (static::isMediaTranslationEnabled()) {
+						if (Utilities::woocommerceVersionCheck('3.0')) 
+						{
             add_filter(
                     'woocommerce_product_get_gallery_image_ids', array($this, 'translateGallery')
             );
+        }
+						else
+						{
+							add_filter(
+											'woocommerce_product_gallery_attachment_ids', array($this, 'translateGallery')
+							);
+						}
+
         }
     }
 

--- a/src/Hyyan/WPI/Media.php
+++ b/src/Hyyan/WPI/Media.php
@@ -26,7 +26,7 @@ class Media
     {
         if (static::isMediaTranslationEnabled()) {
             add_filter(
-                    'woocommerce_product_gallery_attachment_ids', array($this, 'translateGallery')
+                    'woocommerce_product_get_gallery_image_ids', array($this, 'translateGallery')
             );
         }
     }

--- a/src/Hyyan/WPI/Order.php
+++ b/src/Hyyan/WPI/Order.php
@@ -116,14 +116,7 @@ class Order
      */
     public function translateProductNameInOrdersDetails($name, $item, $is_visible = false)
     {
-				if (Utilities::woocommerceVersionCheck('3.0')) 
-				{
-        $id = $item->get_product_id();
-  			}
-				else
-				{
-					$id = $item['item_meta']['_product_id'][0];
-				}
+				$id = (Utilities::woocommerceVersionCheck('3.0')) ? $item->get_product_id() : $item['item_meta']['_product_id'][0];
         $product = Utilities::getProductTranslationByID($id);
         if ($product) {
 					if (Utilities::woocommerceVersionCheck('3.0')) 
@@ -137,9 +130,11 @@ class Order
 					else
 					{
 						if (!$is_visible) {
-                return $product->post->post_title;
+								return get_post($product->get_id())->post_title;
+                //return $product->post->post_title;
             } else {
-                return sprintf('<a href="%s">%s</a>', get_permalink($product->id), $product->post->post_title);
+								return sprintf('<a href="%s">%s</a>', get_permalink($product->get_id()), get_post($product->get_id())->post_title);
+                //return sprintf('<a href="%s">%s</a>', get_permalink($product->id), $product->post->post_title);
             }
 					}
         } else {

--- a/src/Hyyan/WPI/Order.php
+++ b/src/Hyyan/WPI/Order.php
@@ -115,13 +115,13 @@ class Order
      */
     public function translateProductNameInOrdersDetails($name, $item, $is_visible = false)
     {
-        $id = $item['item_meta']['_product_id'][0];
+        $id = $item->get_product_id();
         $product = Utilities::getProductTranslationByID($id);
         if ($product) {
             if (!$is_visible) {
-                return $product->post->post_title;
+                return $product->get_name();
             } else {
-                return sprintf('<a href="%s">%s</a>', get_permalink($product->id), $product->post->post_title);
+                return sprintf('<a href="%s">%s</a>', get_permalink($product->get_id()), $product->get_name());
             }
         } else {
             return $name;
@@ -133,14 +133,35 @@ class Order
      *
      * Will correct the query to display orders from all languages
      *
-     * @param array $query
+     * @param array $query  query arguments
      *
      * @return array
      */
     public function correctMyAccountOrderQuery(array $query)
     {
+        if (Utilities::woocommerceVersionCheck('2.7')) {
+            add_filter('woocommerce_order_data_store_cpt_get_orders_query', array($this, 'correctGetOrderQuery'), 10, 2);
+        }
         $query['lang'] = implode(',', pll_languages_list());
 
+        return $query;
+    }
+    
+    /**
+     * Correct wc_get_orders query for the My Account view orders page.
+     *
+     * Will correct the query to display orders from all languages
+     *
+     * @param array $query  WP_Query arguments
+     * @param array $args   wc_get_orders query args
+     *
+     * @return array
+     */
+    public function correctGetOrderQuery($query, $args) {
+        if (isset($args['lang'])) {
+            $query['lang'] = $args['lang'];
+        }
+        
         return $query;
     }
 

--- a/src/Hyyan/WPI/Order.php
+++ b/src/Hyyan/WPI/Order.php
@@ -9,6 +9,7 @@
  */
 
 namespace Hyyan\WPI;
+use Hyyan\WPI\Utilities;
 
 /**
  * Order.
@@ -115,14 +116,32 @@ class Order
      */
     public function translateProductNameInOrdersDetails($name, $item, $is_visible = false)
     {
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         $id = $item->get_product_id();
+  			}
+				else
+				{
+					$id = $item['item_meta']['_product_id'][0];
+				}
         $product = Utilities::getProductTranslationByID($id);
         if ($product) {
+					if (Utilities::woocommerceVersionCheck('3.0')) 
+					{
             if (!$is_visible) {
                 return $product->get_name();
             } else {
                 return sprintf('<a href="%s">%s</a>', get_permalink($product->get_id()), $product->get_name());
             }
+					}
+					else
+					{
+						if (!$is_visible) {
+                return $product->post->post_title;
+            } else {
+                return sprintf('<a href="%s">%s</a>', get_permalink($product->id), $product->post->post_title);
+            }
+					}
         } else {
             return $name;
         }
@@ -161,7 +180,6 @@ class Order
         if (isset($args['lang'])) {
             $query['lang'] = $args['lang'];
         }
-        
         return $query;
     }
 

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -37,14 +37,7 @@ class Plugin
 		 */
 		public function hyyan_settings_link( $links ) {
 //FIX: #132 Add link to settings page
-/* get_admin_url() should be correct and works fine for other plugins, but in Hyyan context it produces: Fatal error: Uncaught Error: Call to undefined function Hyyan\WPI\ get_admin_url()
-			if ( !function_exists('get_admin_url') ) {
-		   require_once( ABSPATH . '/wp-includes/link-template.php' );
-			}
-			$mylinks = array('<a href="'. \get_admin_url( null, 'options-general.php?page=hyyan-wpi' ) . '">' . 
-				esc_html__( 'Settings', ' woo-poly-integration' ) . '</a>', );
-*/
-			$mylinks = array('<a href="options-general.php?page=hyyan-wpi">' . esc_html__( 'Settings', ' woo-poly-integration' ) . '</a>', );
+			$mylinks = array('<a href="' . admin_url() . 'options-general.php?page=hyyan-wpi">' . esc_html__( 'Settings', ' woo-poly-integration' ) . '</a>', );
 			return array_merge( $links, $mylinks );
 		}
 

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -30,6 +30,24 @@ class Plugin
         add_action('plugins_loaded', array($this, 'loadTextDomain'));
     }
 
+		/**
+		 * Settings link that appears on the plugins overview page
+		 * @param array $links
+		 * @return array
+		 */
+		public function hyyan_settings_link( $links ) {
+//FIX: #132 Add link to settings page
+/* get_admin_url() should be correct and works fine for other plugins, but in Hyyan context it produces: Fatal error: Uncaught Error: Call to undefined function Hyyan\WPI\ get_admin_url()
+			if ( !function_exists('get_admin_url') ) {
+		   require_once( ABSPATH . '/wp-includes/link-template.php' );
+			}
+			$mylinks = array('<a href="'. \get_admin_url( null, 'options-general.php?page=hyyan-wpi' ) . '">' . 
+				esc_html__( 'Settings', ' woo-poly-integration' ) . '</a>', );
+*/
+			$mylinks = array('<a href="options-general.php?page=hyyan-wpi">' . esc_html__( 'Settings', ' woo-poly-integration' ) . '</a>', );
+			return array_merge( $links, $mylinks );
+		}
+
     /**
      * Load plugin langauge file.
      */
@@ -65,6 +83,8 @@ class Plugin
         );
 
         $this->registerCore();
+				add_filter( 'plugin_action_links_woo-poly-integration/__init__.php', array($this,'hyyan_settings_link') );
+
     }
 
     /**

--- a/src/Hyyan/WPI/Product/Stock.php
+++ b/src/Hyyan/WPI/Product/Stock.php
@@ -52,9 +52,18 @@ class Stock
         $items = $order->get_items();
 
         /* Reduce stock */
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         foreach ($items as $item) {
             $this->change($item, self::STOCK_REDUCE_ACTION);
         }
+    }
+				else
+				{
+					foreach ($items as $item) {
+							$this->change_old($item, self::STOCK_REDUCE_ACTION);
+					}
+				}		
     }
 
     /**
@@ -73,11 +82,20 @@ class Stock
         $items = $order->get_items();
 
         /* Increase stock */
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
         foreach ($items as $item) {
             $item->change = $change;
             $this->change($item, self::STOCK_INCREASE_ACTION);
         }
-
+				}
+				else
+				{
+					foreach ($items as $item) {
+							$item->change = $change;
+							$this->change_old($item, self::STOCK_INCREASE_ACTION);
+					}
+				}		
         return $change;
     }
 
@@ -89,18 +107,11 @@ class Stock
      */
 protected function change( \WC_Order_Item_Product $item, $action = self::STOCK_REDUCE_ACTION )
     {
-				if (Utilities::woocommerceVersionCheck('3.0')) 
-				{
-        $productID = $item->get_product_id();
-	  		}
-				else
-				{
-					$productID = $item['product_id'];
-				}
+				$productID = Utilities::get_order_item_productid($item);
         $productObject = wc_get_product($productID);
         $productLang = pll_get_post_language($productID);
 
-        $variationID = $item->get_variation_id();
+        $variationID = Utilities::get_order_item_variationid($item);
 
         /* Handle Products */
         if ($productObject && $productLang) {
@@ -119,8 +130,8 @@ protected function change( \WC_Order_Item_Product $item, $action = self::STOCK_R
                     'decrease' :
                     'increase';
             $change = ($action === self::STOCK_REDUCE_ACTION) ?
-              $item->get_quantity() :
-          		$item->change;
+              Utilities::get_order_item_quantity($item) :
+          		Utilities::get_order_item_change($item);
 
             /* Sync stock for all translation */
             foreach ($translations as $ID) {
@@ -160,4 +171,66 @@ protected function change( \WC_Order_Item_Product $item, $action = self::STOCK_R
             }
         }
     }
+		
+		/** OLD WOO < 2-6 version
+     * Change the product stock in the given order item.
+     *
+     * @param array  $item   the order data
+     * @param string $action STOCK_REDUCE_ACTION | STOCK_INCREASE_ACTION
+     */
+    protected function change_old(array $item, $action = self::STOCK_REDUCE_ACTION)
+    {
+        $productID = $item['product_id'];
+        $productObject = wc_get_product($productID);
+        $productLang = pll_get_post_language($productID);
+        $variationID = $item['variation_id'];
+        /* Handle Products */
+        if ($productObject && $productLang) {
+            /* Get the translations IDS */
+            $translations = Utilities::getProductTranslationsArrayByObject(
+                            $productObject
+            );
+            /* Remove the current product from translation array */
+            unset($translations[$productLang]);
+            $isManageStock = $productObject->managing_stock();
+            $isVariation = $variationID && $variationID > 0;
+            $method = ($action === self::STOCK_REDUCE_ACTION) ?
+                    'reduce_stock' :
+                    'increase_stock';
+            $change = ($action === self::STOCK_REDUCE_ACTION) ?
+                    $item['qty'] :
+                    $item['change'];
+            /* Sync stock for all translation */
+            foreach ($translations as $ID) {
+                /* Only if product is managing stock */
+                if ($isManageStock) {
+                    if (($translation = wc_get_product($ID))) {
+                        $translation->$method($change);
+                    }
+                }
+                $general = Settings::getOption(
+                                'general', MetasList::getID(), array('total_sales')
+                );
+                if (in_array('total_sales', $general)) {
+                    update_post_meta(
+                            $ID, 'total_sales', get_post_meta($productID, 'total_sales', true)
+                    );
+                }
+            }
+            /* Handle variation stock UNLESS stock is managed on the parent */
+            if (($isVariation) && !($isManageStock)) {
+                $posts = Variation::getRelatedVariation($variationID);
+                foreach ($posts as $post) {
+                    if ($post->ID == $variationID) {
+                        continue;
+                    }
+                    $variation = wc_get_product($post);
+                    if ($variation && $variation->managing_stock()) {
+                        $variation->$method($change);
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/src/Hyyan/WPI/Product/Stock.php
+++ b/src/Hyyan/WPI/Product/Stock.php
@@ -74,7 +74,7 @@ class Stock
 
         /* Increase stock */
         foreach ($items as $item) {
-            $item['change'] = $change;
+            $item->change = $change;
             $this->change($item, self::STOCK_INCREASE_ACTION);
         }
 
@@ -87,13 +87,13 @@ class Stock
      * @param array  $item   the order data
      * @param string $action STOCK_REDUCE_ACTION | STOCK_INCREASE_ACTION
      */
-    protected function change(array $item, $action = self::STOCK_REDUCE_ACTION)
+protected function change( \WC_Order_Item_Product $item, $action = self::STOCK_REDUCE_ACTION )
     {
-        $productID = $item['product_id'];
+        $productID = $item->get_product_id();
         $productObject = wc_get_product($productID);
         $productLang = pll_get_post_language($productID);
 
-        $variationID = $item['variation_id'];
+        $variationID = $item->get_variation_id();
 
         /* Handle Products */
         if ($productObject && $productLang) {
@@ -112,8 +112,8 @@ class Stock
                     'reduce_stock' :
                     'increase_stock';
             $change = ($action === self::STOCK_REDUCE_ACTION) ?
-                    $item['qty'] :
-                    $item['change'];
+              $item->get_quantity() :
+          		$item->change;
 
             /* Sync stock for all translation */
             foreach ($translations as $ID) {

--- a/src/Hyyan/WPI/Product/Variable.php
+++ b/src/Hyyan/WPI/Product/Variable.php
@@ -203,7 +203,7 @@ class Variable
         // Don't sync if not a Variable Product
         $product = wc_get_product($post_id);
 
-        if ($product && 'simple' === $product->product_type && Utilities::maybeVariableProduct($product)) {
+        if ($product && 'simple' === $product->get_type() && Utilities::maybeVariableProduct($product)) {
             // Maybe is Variable Product - new translations of Variable Products are first created as simple
 
             // Only need to sync for the new translation from source product
@@ -213,7 +213,7 @@ class Variable
             if (!empty($attributes_translation) && isset($attributes_translation[$_GET['new_lang']])) {
                 update_post_meta($product->get_id(), '_default_attributes', $attributes_translation[$_GET['new_lang']]);
             }
-        } elseif ($product && 'variable' === $product->product_type) {
+        } elseif ($product && 'variable' === $product->get_type()) {
             // Variable Product
 
             // For each product translation, get the translated (default) terms/attributes
@@ -286,8 +286,8 @@ class Variable
      */
     public function extendFieldsLockerSelectors(array $selectors)
     {
-        $selectors[] = '#variable_product_options :input';
-
+        //FIX: #128 allow variable product description to be translated
+				$selectors[] = '#variable_product_options :input:not([name^="variable_description"])';
         return $selectors;
     }
 

--- a/src/Hyyan/WPI/Product/Variable.php
+++ b/src/Hyyan/WPI/Product/Variable.php
@@ -135,7 +135,7 @@ class Variable
 
             // _default_attributes meta should be unique
             if ($product && current_filter() === 'add_post_metadata') {
-                $old_value = get_post_meta($product->id, '_default_attributes');
+                $old_value = get_post_meta($product->get_id(), '_default_attributes');
                 return empty($old_value) ? $check : false;
             }
 
@@ -143,7 +143,7 @@ class Variable
             // New translations of Variable Products are first created as simple
             if ($product && Utilities::maybeVariableProduct($product)) {
                 // Try Polylang first
-                $lang = pll_get_post_language($product->id);
+                $lang = pll_get_post_language($product->get_id());
 
                 if (!$lang) {
                     // Must be a new translation and Polylang doesn't stored the language yet
@@ -211,19 +211,19 @@ class Variable
             $attributes_translation = Utilities::getDefaultAttributesTranslation($_GET['from_post'], $_GET['new_lang']);
 
             if (!empty($attributes_translation) && isset($attributes_translation[$_GET['new_lang']])) {
-                update_post_meta($product->id, '_default_attributes', $attributes_translation[$_GET['new_lang']]);
+                update_post_meta($product->get_id(), '_default_attributes', $attributes_translation[$_GET['new_lang']]);
             }
         } elseif ($product && 'variable' === $product->product_type) {
             // Variable Product
 
             // For each product translation, get the translated (default) terms/attributes
-            $attributes_translation = Utilities::getDefaultAttributesTranslation($product->id);
+            $attributes_translation = Utilities::getDefaultAttributesTranslation($product->get_id());
             $langs                  = pll_languages_list();
 
             foreach ($langs as $lang) {
-                $translation_id = pll_get_post($product->id, $lang);
+                $translation_id = pll_get_post($product->get_id(), $lang);
 
-                if ($translation_id != $product->id) {
+                if ($translation_id != $product->get_id()) {
                     update_post_meta($translation_id, '_default_attributes', $attributes_translation[$lang]);
                 }
             }

--- a/src/Hyyan/WPI/Product/Variation.php
+++ b/src/Hyyan/WPI/Product/Variation.php
@@ -216,6 +216,32 @@ class Variation
     }
 
     /**
+     * Sync Product Shipping Class.
+     * 
+     * Shipping Class translation is not supported after WooCommerce 2.6
+     * but it is still implemented by WooCommerce as a taxonomy. Therefore,
+     * Polylang will not copy the Shipping Class meta.
+     *
+     * @param int $from product variation ID
+     * @param int $to   product variation ID
+     */
+    public function syncShippingClass($from, $to)
+    {
+			// Product edit - update shipping class of all product translations
+			$variation_from = wc_get_product($from);
+            
+			if ($variation_from) {           
+				$shipping_class = $variation_from->get_shipping_class();
+				if ($shipping_class){
+					$shipping_terms = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
+					if ($shipping_terms) {
+						wp_set_post_terms( $to, array( $shipping_terms->term_id ), 'product_shipping_class' );
+					}
+				}
+			}    
+		}
+
+    /**
      * Copy variation meta.
      *
      * The method follow the same method polylang use to sync metas between
@@ -246,8 +272,6 @@ class Variation
             $metas_nosync[] = '_variation_description';
         }
         
-        error_log(print_r($metas_nosync, true));
-
         /* synchronize */
         foreach ($keys as $key) {
             if (!in_array($key, $metas_nosync)) {
@@ -287,5 +311,7 @@ class Variation
                 }
             }
         }
+				//add shipping class not included in metas as now a taxonomy
+				$this->syncShippingClass($from, $to);
     }
 }

--- a/src/Hyyan/WPI/Product/Variation.php
+++ b/src/Hyyan/WPI/Product/Variation.php
@@ -57,7 +57,7 @@ class Variation
             return false;
         }
 
-        if ($this->to->id === $this->from->id) {
+        if ($this->to->get_id() === $this->from->get_id()) {
 
             /*
              * In such a case just add the duplicate meta
@@ -90,7 +90,7 @@ class Variation
                     'meta_key' => self::DUPLICATE_KEY,
                     'meta_value' => $variation['variation_id'],
                     'post_type' => 'product_variation',
-                    'post_parent' => $this->to->id,
+                    'post_parent' => $this->to->get_id(),
                 ));
 
                 switch (count($posts)) {
@@ -171,11 +171,11 @@ class Variation
     {
         // Add the duplicate meta to the default language product variation,
         // just in case the product was created before plugin acivation.
-        $this->addDuplicateMeta( $variation->variation_id );
-        
-        $data = (array) get_post($variation->variation_id);
+        $this->addDuplicateMeta($variation->get_id());
+
+        $data = (array) get_post($variation->get_id());
         unset($data['ID']);
-        $data['post_parent'] = $this->to->id;
+        $data['post_parent'] = $this->to->get_id();
         $ID = wp_insert_post($data);
 
         if ($ID) {
@@ -183,7 +183,7 @@ class Variation
                     $ID, self::DUPLICATE_KEY, $metas['variation_id']
             );
 
-            $this->copyVariationMetas($variation->variation_id, $ID);
+            $this->copyVariationMetas($variation->get_id(), $ID);
         }
     }
 
@@ -196,7 +196,7 @@ class Variation
      */
     protected function update(\WC_Product_Variation $variation, \WP_Post $post, array $metas)
     {
-        $this->copyVariationMetas($variation->variation_id, $post->ID);
+        $this->copyVariationMetas($variation->get_id(), $post->ID);
     }
     
     /**
@@ -227,22 +227,30 @@ class Variation
     protected function copyVariationMetas($from, $to)
     {
         /* copy or synchronize post metas and allow plugins to do the same */
-        $metas_from = get_post_custom($from);
-        $metas_to = get_post_custom($to);
+        $metas_from     = get_post_custom($from);
+        $metas_to       = get_post_custom($to);
 
         /* get public and protected meta keys */
-        $keys = array_unique(array_merge(array_keys($metas_from), array_keys($metas_to)));
+        $keys           = array_unique(array_merge(array_keys($metas_from), array_keys($metas_to)));
+        
+        /* metas disabled for sync */
+        $metas_nosync   = Meta::getDisabledProductMetaToCopy();
+
+        /*
+         * _variation_description meta is a text-based string and generally needs to be translated.
+         * _variation_description meta is copied from product in default language to the translations
+         * when the translation is first created. But the meta can be edited/changed and will not be
+         * overwriten when product is saved or updated.
+         */
+        if (isset($metas_to['_variation_description'])) {
+            $metas_nosync[] = '_variation_description';
+        }
+        
+        error_log(print_r($metas_nosync, true));
 
         /* synchronize */
         foreach ($keys as $key) {
-            /*
-             * _variation_description meta is a text-based string and generally needs to be translated.
-             * 
-             * _variation_description meta is copied from product in default language to the translations
-             * when the translation is first created. But the meta can be edited/changed and will not be
-             * overwriten when product is saved or updated.
-             */
-            if ( '_variation_description' != $key || !isset($metas_to[$key])) {
+            if (!in_array($key, $metas_nosync)) {
                 /*
                  * the synchronization process of multiple values custom fields is
                  * easier if we delete all metas first
@@ -256,7 +264,7 @@ class Variation
                         foreach ($metas_from[$key] as $termSlug) {
                             $term = get_term_by('slug', $termSlug, $tax);
                             if ($term) {
-                                $lang = isset($_GET['new_lang']) ? esc_attr($_GET['new_lang']) : pll_get_post_language($this->to->id);
+                                $lang = isset($_GET['new_lang']) ? esc_attr($_GET['new_lang']) : pll_get_post_language($this->to->get_id());
                                 if ($translated_term = pll_get_term($term->term_id, $lang)) {
                                     $translated[] = get_term_by('id', $translated_term, $tax)->slug;
                                 } else {

--- a/src/Hyyan/WPI/Reports.php
+++ b/src/Hyyan/WPI/Reports.php
@@ -145,7 +145,7 @@ class Reports
 
             if ($translation) {
                 $data->from = $data->product_id;
-                $data->product_id = $translation->id;
+                $data->product_id = $translation->get_id();
             }
             $translated [] = $data;
         }

--- a/src/Hyyan/WPI/Shipping.php
+++ b/src/Hyyan/WPI/Shipping.php
@@ -135,9 +135,9 @@ class Shipping
 
         // Rest of the World zone
         $zone = new \WC_Shipping_Zone();
-        $zones[ $zone->get_zone_id() ] = $zone->get_data();
-        $zones[ $zone->get_zone_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
-        $zones[ $zone->get_zone_id() ]['shipping_methods'] = $zone->get_shipping_methods();
+        $zones[ $zone->get_id() ] = $zone->get_data();
+        $zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
+        $zones[ $zone->get_id() ]['shipping_methods'] = $zone->get_shipping_methods();
 
         // Add user configured zones
         $zones = array_merge($zones, \WC_Shipping_Zones::get_zones());

--- a/src/Hyyan/WPI/Shipping.php
+++ b/src/Hyyan/WPI/Shipping.php
@@ -12,6 +12,7 @@ namespace Hyyan\WPI;
 
 use Hyyan\WPI\Admin\Settings;
 use Hyyan\WPI\Admin\Features;
+use Hyyan\WPI\Utilities;
 
 /**
  * Shipping.

--- a/src/Hyyan/WPI/Taxonomies/Attributes.php
+++ b/src/Hyyan/WPI/Taxonomies/Attributes.php
@@ -96,10 +96,10 @@ class Attributes implements TaxonomiesInterface
         }
 
         $stringTranslationURL = add_query_arg(array(
-            'page' => 'mlang',
-            'tab' => 'strings',
+            'page' => 'mlang_strings',
+            //'tab' => 'strings',
             'group' => __('Woocommerce Attributes', 'woo-poly-integration'),
-        ), admin_url('options-general.php'));
+        ), admin_url('admin.php'));
 
         /* Add attribute translate button */
         $buttonID = 'attrs-label-translation-button';

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -54,7 +54,7 @@ final class Utilities
      */
     public static function getProductTranslationsArrayByObject(\WC_Product $product, $excludeDefault = false)
     {
-        return static::getProductTranslationsArrayByID($product->id, $excludeDefault);
+        return static::getProductTranslationsArrayByID($product->get_id(), $excludeDefault);
     }
 
     /**
@@ -86,7 +86,7 @@ final class Utilities
      */
     public static function getProductTranslationByObject(\WC_Product $product, $slug = '')
     {
-        $productTranslationID = pll_get_post($product->id, $slug);
+        $productTranslationID = pll_get_post($product->get_id(), $slug);
 
         if ($productTranslationID) {
             $translated = wc_get_product($productTranslationID);
@@ -321,7 +321,7 @@ final class Utilities
             $is_translation  = isset($_GET['from_post']) && isset($_GET['new_lang']);
             $has_variations  = get_children(array(
                     'post_type'   => 'product_variation',
-                    'post_parent' => $product->id
+                    'post_parent' => $product->get_id()
                 ));
 
             if ($add_new_product && $is_translation && $has_variations)

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -255,7 +255,7 @@ final class Utilities
         $product = wc_get_product( $product_id );
         $translated_attributes = array();
 
-        if ($product && 'variable' === $product->product_type) {
+        if ($product && 'variable' === $product->get_type()) {
             $default_attributes = $product->get_variation_default_attributes();
             $terms = array(); // Array of terms: if the term is taxonomy each value is a term object, otherwise an array (term slug => term value)
             $langs = array();
@@ -313,9 +313,9 @@ final class Utilities
         if (is_numeric($product))
             $product = wc_get_product(asbint($product));
 
-        if ($product && 'variable' === $product->product_type)
+        if ($product && 'variable' === $product->get_type())
             return true;
-        elseif ($product && 'simple' === $product->product_type) {
+        elseif ($product && 'simple' === $product->get_type()) {
             $current_screen  = function_exists('get_current_screen') ? get_current_screen() : false;
             $add_new_product = $current_screen && $current_screen->post_type === 'product' && $current_screen->action === 'add';
             $is_translation  = isset($_GET['from_post']) && isset($_GET['new_lang']);

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -256,7 +256,14 @@ final class Utilities
         $translated_attributes = array();
 
         if ($product && 'variable' === $product->get_type()) {
+						if (Utilities::woocommerceVersionCheck('3.0')) 
+						{
             $default_attributes = $product->get_default_attributes();
+						}
+						else
+						{
+							$default_attributes = $product->get_variation_default_attributes();
+						}
             $terms = array(); // Array of terms: if the term is taxonomy each value is a term object, otherwise an array (term slug => term value)
             $langs = array();
 
@@ -347,6 +354,143 @@ final class Utilities
 				else
 				{
 					return $order->payment_method;
+				}
+		}
+		/**
+     * get billing country for order independent of wooCommerce version
+     *
+     * @param WC_Order $order
+     *
+     * @return string payment method name.
+     */
+    public static function get_billing_country($order)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+					return $order->get_billing_country();
+				}
+				else
+				{
+					return $order->billing_country;
+				}
+		}
+
+		/**
+     * get product id for order item independent of wooCommerce version
+     *
+     * @param WC_Order_Item_Product $item
+     *
+     * @return id
+     */
+    public static function get_order_item_productid($item)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+	        return $item->get_product_id();
+	  		}
+				else
+				{
+					return $item['product_id'];
+				}
+		}
+
+		
+		/**
+     * get variation id for order item independent of wooCommerce version
+     *
+     * @param WC_Order_Item_Product $item
+     *
+     * @return id
+     */
+    public static function get_order_item_variationid($item)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+	        return $item->get_variation_id();
+	  		}
+				else
+				{
+					return $item['variation_id'];
+				}
+		}
+
+				
+		/**
+     * get quantity for order item independent of wooCommerce version
+     *
+     * @param WC_Order_Item_Product $item
+     *
+     * @return integer quantity
+     */
+    public static function get_order_item_quantity($item)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+	        return $item->get_quantity();
+	  		}
+				else
+				{
+					return $item['qty'];
+				}
+		}
+
+		/**
+     * get change for order item independent of wooCommerce version
+     *
+     * @param WC_Order_Item_Product $item
+     *
+     * @return integer change
+     */
+    public static function get_order_item_change($item)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+	        return $item->change;
+	  		}
+				else
+				{
+					return $item['change'];
+				}
+		}
+
+		/**
+     * get order languate independent of wooCommerce version
+     *
+     * @param WC_Order order
+     *
+     * @return string language
+     */
+    public static function get_orderid($order)
+    {		
+				// Get order language
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+	        return $order->get_id();
+				}
+				else
+				{
+	        return $order->id;
+				}
+				
+		}
+
+
+
+		/**
+     * get id for variation parent independent of wooCommerce version
+     *
+     * @param WC_Product variation
+     *
+     * @return integer id of variation parent post
+     */
+    public static function get_variation_parentid($variation)
+    {		
+				if ($variation){
+					return (Utilities::woocommerceVersionCheck('3.0')) ? $variation->get_parent_id() : $variation->parent->get_id();
+				}
+				else
+				{
+					return null;
 				}
 		}
 }

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -330,4 +330,23 @@ final class Utilities
 
         return false;
     }
+		
+    /**
+     * get payment method for order independent of wooCommerce version
+     *
+     * @param WC_Order $order
+     *
+     * @return string payment method name.
+     */
+    public static function get_payment_method($order)
+    {		
+				if (Utilities::woocommerceVersionCheck('3.0')) 
+				{
+					return $order->get_payment_method();
+				}
+				else
+				{
+					return $order->payment_method;
+				}
+		}
 }

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -256,7 +256,7 @@ final class Utilities
         $translated_attributes = array();
 
         if ($product && 'variable' === $product->get_type()) {
-            $default_attributes = $product->get_variation_default_attributes();
+            $default_attributes = $product->get_default_attributes();
             $terms = array(); // Array of terms: if the term is taxonomy each value is a term object, otherwise an array (term slug => term value)
             $langs = array();
 


### PR DESCRIPTION
Email Translations fixes #140, fixes #142, fixes #143, fixes #89, fixes #70
Added translation management for:
* On Hold Order Email
* Cancelled Order Email
* Failed Order Email
* Recipient [ie Shop] email for New/Cancel/Failed emails
* Footer test, From name and From address on all emails 