### PR TITLE
Added support for cart item custom variation types

### DIFF
--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -92,22 +92,18 @@ class Cart
         // By default, returns the same input
         $cart_item_data_translation = $cart_item_data;
 
-        switch ($cart_item_data->get_type()) {
-            case 'variation':
-                $variation_translation   = $this->getVariationTranslation($cart_variation_id);
-                $cart_item_data_translation = $variation_translation ? $variation_translation : $cart_item_data_translation;
-                break;
-
-            case 'simple':
-            default:
-                $product_translation        = Utilities::getProductTranslationByID($cart_product_id);
-                $cart_item_data_translation = $product_translation ? $product_translation : $cart_item_data_translation;
-                break;
+        if (strpos($cart_item_data->get_type(), 'variation') !== false) {
+            $variation_translation      = $this->getVariationTranslation($cart_variation_id);
+            $cart_item_data_translation = $variation_translation ? $variation_translation : $cart_item_data_translation;
+        }
+        else {
+            $product_translation        = Utilities::getProductTranslationByID($cart_product_id);
+            $cart_item_data_translation = $product_translation ? $product_translation : $cart_item_data_translation;
         }
 
         return $cart_item_data_translation;
     }
-    
+
     /**
      * Replace products id in cart with id of product translation.
      *

--- a/src/Hyyan/WPI/Coupon.php
+++ b/src/Hyyan/WPI/Coupon.php
@@ -219,7 +219,7 @@ class Coupon
         $result  = array($ID);
         $product = wc_get_product($ID);
 
-        if ($product && $product->get_type() === 'variation') {
+        if ($product && strpos($product->get_type(), 'variation') !== false) {
             $IDS = Product\Variation::getRelatedVariation($ID, true);
             if (is_array($IDS)) {
                 $result = array_merge($result, $IDS);


### PR DESCRIPTION
This pull request fixes WooCommerce Subscriptions interval on cart item.

Before(every 3 months is selected, but shows every 6):
![screen shot 2017-08-30 at 15 06 13](https://user-images.githubusercontent.com/17280721/29872606-fb148a06-8d98-11e7-9cb0-768e0a7e0915.png)

After: 
![screen shot 2017-08-30 at 15 04 51](https://user-images.githubusercontent.com/17280721/29872620-090e4f02-8d99-11e7-8f37-bd1fc6f70777.png)


