### PR TITLE
Fix ajax endpoint url, fixes #240

### DIFF
--- a/src/Hyyan/WPI/Ajax.php
+++ b/src/Hyyan/WPI/Ajax.php
@@ -19,23 +19,23 @@ namespace Hyyan\WPI;
  */
 class Ajax {
 
-	/**
-	 * Construct object.
-	 */
-	public function __construct() {
-		add_filter( 'pll_home_url_white_list', array( $this, 'pll_home_url_white_list' ) );
-	}
+    /**
+     * Construct object.
+     */
+    public function __construct() {
+        add_filter( 'pll_home_url_white_list', array( $this, 'pll_home_url_white_list' ) );
+    }
 
-	/**
-	 * Add WooCommerce class-wc-ajax.php to the Polylang home_url white list
-	 *
-	 * @param array $white_list Polylang home_url white list
-	 *
-	 * @return array filtered white list
-	 */
-	public function pll_home_url_white_list( $white_list ) {
-		$white_list[] = array( 'file' => 'class-wc-ajax.php' );
-		return $white_list;
-	}
+    /**
+     * Add WooCommerce class-wc-ajax.php to the Polylang home_url white list
+     *
+     * @param array $white_list Polylang home_url white list
+     *
+     * @return array filtered white list
+     */
+    public function pll_home_url_white_list( $white_list ) {
+        $white_list[] = array( 'file' => 'class-wc-ajax.php' );
+        return $white_list;
+    }
 
 }

--- a/src/Hyyan/WPI/Ajax.php
+++ b/src/Hyyan/WPI/Ajax.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the hyyan/woo-poly-integration plugin.
+ * (c) Hyyan Abo Fakher <hyyanaf@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hyyan\WPI;
+
+/**
+ * Ajax.
+ *
+ * Handle Ajax
+ *
+ * @author Marian Kadanka <marian.kadanka@gmail.com>
+ */
+class Ajax {
+
+	/**
+	 * Construct object.
+	 */
+	public function __construct() {
+		add_filter( 'pll_home_url_white_list', array( $this, 'pll_home_url_white_list' ) );
+	}
+
+	/**
+	 * Add WooCommerce class-wc-ajax.php to the Polylang home_url white list
+	 *
+	 * @param array $white_list Polylang home_url white list
+	 *
+	 * @return array filtered white list
+	 */
+	public function pll_home_url_white_list( $white_list ) {
+		$white_list[] = array( 'file' => 'class-wc-ajax.php' );
+		return $white_list;
+	}
+
+}

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -191,6 +191,7 @@ class Plugin
         new Breadcrumb();
         new Tax();
         new LocaleNumbers();
+		  new Ajax();
     }
 
     /**

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -191,7 +191,7 @@ class Plugin
         new Breadcrumb();
         new Tax();
         new LocaleNumbers();
-		  new Ajax();
+        new Ajax();
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

- Please make sure your changes respect the PSR-2 Coding Standards:
  - http://www.php-fig.org/psr/psr-2/
- In case you introduced a new action or filter hook, please use HooksInterface.php to document it 
- Please create tests, if you can.
-->

This pull request fixes #240 

#### What's Included in This Pull Request

WooCommerce 3.2.0 introduced different handling of Ajax endpoint
URLs, including call to home_url() function, for more info see
woocommerce/woocommerce#16991

This breaks Polylang language detection if language is set from the
directory name in pretty permalinks.

To address this issue we need to add WooCommerce class-wc-ajax.php
file to the white list of the Polylang home_url filter, enabling
home_url() function to return correct URL according to the language
set.
