### PR TITLE
Fix is_front_page() not working on WC shop page set as site's static front page

### DIFF
--- a/src/Hyyan/WPI/Pages.php
+++ b/src/Hyyan/WPI/Pages.php
@@ -114,8 +114,6 @@ class Pages {
                     $wp->query_vars['post_type'] = 'product';
                 }
             }
-        } else {
-            $wp->query_vars['post_type'] = 'product';
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

- Please make sure your changes respect the PSR-2 Coding Standards:
  - http://www.php-fig.org/psr/psr-2/
- In case you introduced a new action or filter hook, please use HooksInterface.php to document it 
- Please create tests, if you can.
-->

This pull request fixes #252

#### What's Included in This Pull Request

Not sure why this branch of IF conditional set post_type to 'product',
since post_type is not set when using WooCommerce shop page as site's
static front page. Removing this ELSE branch fix the issue and
everything else is working fine.

Tested with WooCommerce 3.1.2 and 3.2.1, switching default languages,
using both shop page as site's front page and on standalone shop
pages in all language versions.