### PR TITLE
Don't change shop URL if the shop page is not translated

### DIFF
--- a/src/Hyyan/WPI/Pages.php
+++ b/src/Hyyan/WPI/Pages.php
@@ -142,6 +142,11 @@ class Pages
 
         if ($shopPage) {
             $shopPageTranslatedID = pll_get_post($shopPageID, $language);
+            
+            if (!$shopPageTranslatedID) {
+                return $result;
+            }
+
             $shopPageTranslation = get_post($shopPageTranslatedID);
 
             if ($shopPageTranslation) {


### PR DESCRIPTION
If the shop page is not translated, the ID returned from pll_get_post will be null. In this case, the language selector would link to the first product in the WP loop.