### PR TITLE
Fixing #299

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .php_cs.cache
 *.gif
 *.gif
+.idea


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

- Please make sure your changes respect the PSR-2 Coding Standards:
  - http://www.php-fig.org/psr/psr-2/
- In case you introduced a new action or filter hook, please use HooksInterface.php to document it 
- Please create tests, if you can.
-->

This pull request fixes #299 .

#### What's Included in This Pull Request

* Getting the correct product ID in case of IPN
* Skipping the correct product to avoid Incorrect Stock Sync

The changes will affect both IPN and non IPN call but does not change how the non-IPN works.

One thing I did not check is if the variations are impacted by the bug (we don't use variations).
