### PR TITLE
Fix Ajax endpoint URL again, fixes #319

### DIFF
--- a/src/Hyyan/WPI/Ajax.php
+++ b/src/Hyyan/WPI/Ajax.php
@@ -25,19 +25,22 @@ class Ajax
      */
     public function __construct()
     {
-        add_filter('pll_home_url_white_list', array( $this, 'pll_home_url_white_list' ));
+        add_filter('woocommerce_ajax_get_endpoint', array($this, 'filter_woocommerce_ajax_get_endpoint'), 10, 2);
     }
 
     /**
-     * Add WooCommerce class-wc-ajax.php to the Polylang home_url white list
+     * Filter woocommerce_ajax_get_endpoint URL - replace the path part 
+     * with the correct relative home URL according to the current language 
+     * and append the query string
      *
-     * @param array $white_list Polylang home_url white list
+     * @param string $url WC AJAX endpoint URL to filter
+     * @param string $request
      *
-     * @return array filtered white list
+     * @return string filtered WC AJAX endpoint URL
      */
-    public function pll_home_url_white_list($white_list)
+    public function filter_woocommerce_ajax_get_endpoint($url, $request)
     {
-        $white_list[] = array( 'file' => 'class-wc-ajax.php' );
-        return $white_list;
+        global $polylang;
+        return parse_url($polylang->filters_links->links->get_home_url($polylang->curlang), PHP_URL_PATH) . '?' . parse_url($url, PHP_URL_QUERY);
     }
 }


### PR DESCRIPTION
Another change in WC_AJAX->get_endpoint() implementation - see
woocommerce/woocommerce#19139 - this time it returns relative URLs.
This breaks Polylangs home_url() filter, which can't handle them.

We have to use woocommerce_ajax_get_endpoint filter to alter the
AJAX endpoint URL according to the current language - replace the
path part of the URL with the correct relative home URL and append
the query string. 

This approach is compatible with the latest WooCommerce implementation.
It returns relative home URL of the site, depending on the current language.
So it shouldn't be bugged with potential issues of reverting to the old 
WooCommerce 3.1 way, which have been mentioned at 
https://github.com/woocommerce/woocommerce/issues/19741#issuecomment-381909917

This pull request fixes #319 .