### PR TITLE
Detect woocommerce and polylang if installed as mu-plugins

### DIFF
--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -108,15 +108,21 @@ class Plugin
         $polylang = false;
         $woocommerce = false;
 
+	$polylang_file = 'polylang/polylang.php';
+	$polylang_pro_file = 'polylang-pro/polylang.php';
+	$woocommerce_file = 'woocommerce/woocommerce.php';
+	
         /* check polylang plugin */
         if (
                 (
-                is_plugin_active('polylang/polylang.php') ||
-                is_plugin_active('polylang-pro/polylang.php')
+                is_plugin_active($polylang_file) ||
+                self::isMuPlugin($polylang_file) ||
+                is_plugin_active($polylang_pro_file) ||
+		self::isMuPlugin($polylang_pro_file)
                 ) ||
                 (
-                is_plugin_active_for_network('polylang/polylang.php') ||
-                is_plugin_active_for_network('polylang-pro/polylang.php')
+                is_plugin_active_for_network($polylang_file) ||
+                is_plugin_active_for_network($polylang_pro_file)
                 )
         ) {
             if (isset($GLOBALS['polylang'], \PLL()->model, PLL()->links_model)) {
@@ -128,8 +134,9 @@ class Plugin
 
         /* check woocommerce plugin */
         if (
-                is_plugin_active('woocommerce/woocommerce.php') ||
-                is_plugin_active_for_network('woocommerce/woocommerce.php')
+                is_plugin_active($woocommerce_file) ||
+		self::isMuPlugin($woocommerce_file) ||
+                is_plugin_active_for_network($woocommerce_file)
         ) {
             $woocommerce = true;
         }
@@ -137,6 +144,17 @@ class Plugin
 
         return ($polylang && Utilities::polylangVersionCheck(self::POLYLANG_VERSION)) &&
                 ($woocommerce && Utilities::woocommerceVersionCheck(self::WOOCOMMERCE_VERSION));
+    }
+
+    /**
+     * Check if Mu-plugin
+     * 
+     * @param string $plugin
+     * @return boolean
+     */
+    public static function isMuPlugin($plugin)
+    {
+	return file_exists( trailingslashit( WPMU_PLUGIN_DIR ) . $plugin ) ;
     }
 
     /**

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -108,23 +108,8 @@ class Plugin
         $polylang = false;
         $woocommerce = false;
 
-	$polylang_file = 'polylang/polylang.php';
-	$polylang_pro_file = 'polylang-pro/polylang.php';
-	$woocommerce_file = 'woocommerce/woocommerce.php';
-	
         /* check polylang plugin */
-        if (
-                (
-                is_plugin_active($polylang_file) ||
-                self::isMuPlugin($polylang_file) ||
-                is_plugin_active($polylang_pro_file) ||
-		self::isMuPlugin($polylang_pro_file)
-                ) ||
-                (
-                is_plugin_active_for_network($polylang_file) ||
-                is_plugin_active_for_network($polylang_pro_file)
-                )
-        ) {
+        if (class_exists('Polylang')) {
             if (isset($GLOBALS['polylang'], \PLL()->model, PLL()->links_model)) {
                 if (pll_default_language()) {
                     $polylang = true;
@@ -133,11 +118,7 @@ class Plugin
         }
 
         /* check woocommerce plugin */
-        if (
-                is_plugin_active($woocommerce_file) ||
-		self::isMuPlugin($woocommerce_file) ||
-                is_plugin_active_for_network($woocommerce_file)
-        ) {
+        if (class_exists('WooCommerce')) {
             $woocommerce = true;
         }
 

--- a/src/Hyyan/WPI/Plugin.php
+++ b/src/Hyyan/WPI/Plugin.php
@@ -128,17 +128,6 @@ class Plugin
     }
 
     /**
-     * Check if Mu-plugin
-     * 
-     * @param string $plugin
-     * @return boolean
-     */
-    public static function isMuPlugin($plugin)
-    {
-	return file_exists( trailingslashit( WPMU_PLUGIN_DIR ) . $plugin ) ;
-    }
-
-    /**
      * On Upgrade
      *
      * Run on the plugin updates only once

--- a/src/Hyyan/WPI/Utilities.php
+++ b/src/Hyyan/WPI/Utilities.php
@@ -226,20 +226,7 @@ final class Utilities
      */
     public static function polylangVersionCheck($version)
     {
-        if (!function_exists('get_plugin_data')) {
-            require_once ABSPATH . 'wp-admin/includes/plugin.php';
-        }
-
-        $filepath = ABSPATH . 'wp-content/plugins/polylang/polylang.php';
-        if (! file_exists($filepath)) {
-            $filepath = ABSPATH . 'wp-content/plugins/polylang-pro/polylang.php';
-            if (! file_exists($filepath)) {
-                error_log('Polylang version not tested - polylang file not found');
-                return true;
-            }
-        }
-        $data = get_plugin_data($filepath, false, false);
-        if (version_compare($data['Version'], $version, '>=')) {
+        if (defined('POLYLANG_VERSION') && version_compare(POLYLANG_VERSION, $version, '>=')) {
             return true;
         }
 


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

- Please make sure your changes respect the PSR-2 Coding Standards:
  - http://www.php-fig.org/psr/psr-2/
- In case you introduced a new action or filter hook, please use HooksInterface.php to document it 
- Please create tests, if you can.
-->

This pull request fixes #312 . Woocommerce and Polylang detection if they are installed as mu-plugins

#### What's Included in This Pull Request

* Detect woocommerce and polylang if installed as mu-plugins
* Change the way of checking woocommerce and polylang versions and existence