### PR TITLE
Fall back to $polylang->pref_lang for AJAX endpoint URL when $polylang->curlang is not available.

### DIFF
--- a/src/Hyyan/WPI/Ajax.php
+++ b/src/Hyyan/WPI/Ajax.php
@@ -41,6 +41,7 @@ class Ajax
     public function filter_woocommerce_ajax_get_endpoint($url, $request)
     {
         global $polylang;
-        return parse_url($polylang->filters_links->links->get_home_url($polylang->curlang), PHP_URL_PATH) . '?' . parse_url($url, PHP_URL_QUERY);
+        $lang = ( $polylang->curlang ) ? $polylang->curlang : $polylang->pref_lang;
+        return parse_url($polylang->filters_links->links->get_home_url($lang), PHP_URL_PATH) . '?' . parse_url($url, PHP_URL_QUERY);
     }
 }


### PR DESCRIPTION

This pull request fixes #376.

#### What's Included in This Pull Request
When `$polylang->curlang` is `false`, fallback to `$polylang->pref_lang`. When the user has not selected language from the admin bar `$polylang->curlang` is false and Ajax URL filter returns empty string.