### PR TITLE
Keep the price that's currently saved in the cart

### DIFF
--- a/src/Hyyan/WPI/Cart.php
+++ b/src/Hyyan/WPI/Cart.php
@@ -105,6 +105,11 @@ class Cart
                 break;
         }
 
+        // Keep the price that's currently saved in the cart, because it might have been modified using the "woocommerce_before_calculate_totals" filter
+        $cart_item_data_translation->set_price($cart_item_data->get_price());
+        $cart_item_data_translation->set_regular_price($cart_item_data->get_regular_price());
+        $cart_item_data_translation->set_sale_price($cart_item_data->get_sale_price());
+
         return $cart_item_data_translation;
     }
     


### PR DESCRIPTION
#### Bug description

The "woocommerce_before_calculate_totals" filter is used to modify the price of items in the cart.

There are, for example, plugins that let you define a custom amount for a donation. The price that's displayed in the cart is then the one that the user defined himself. Another common scenario is plugins that modify the price of an item depending on a combination of other items in the cart (e.g. a free magnet if you buy a fridge).

The "translateCartItemProduct" function however overwrites the custom price again with the original product price from the database, which basically breaks all of these plugins. 

#### What's Included in This Pull Request

The change in this pull request restores the price of the original cart item after fetching a translated product to make sure the correct price (that might have been modified using the "woocommerce_before_calculate_totals" filter) is used in the cart.
