### PR TITLE
Fix order email title & subject translations

### DIFF
--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -117,6 +117,7 @@ class Emails
 		$emails			 = $wc_emails->get_emails();
 
         $this->default_settings = apply_filters(HooksInterface::EMAILS_DEFAULT_SETTINGS_FILTER, array(
+			'new_order_recipient'								 => __( $emails[ 'WC_Email_New_Order' ]->get_recipient(), 'woocommerce' ),
 			'new_order_subject'								 => __( $emails[ 'WC_Email_New_Order' ]->get_default_subject(), 'woocommerce' ),
 			'new_order_heading'								 => __( $emails[ 'WC_Email_New_Order' ]->get_default_heading(), 'woocommerce' ),
 			'customer_processing_order_subject'				 => __( $emails[ 'WC_Email_Customer_Processing_Order' ]->get_default_subject(), 'woocommerce' ),

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -678,12 +678,11 @@ class Emails
           return $string;
         }
       }
-      $locale		 = get_locale();
-      $baseLocale	 = get_option( 'WPLANG' );
+      $locale = get_locale();
 
       // Get setting used to register string in the Polylang strings translation table
       $_string = $string; // Store original string to return in case of error
-      // Switch language
+      // Switch language if current locale is not the same as the order
       if ( $order_language != $locale ) {
         $test = $this->getEmailSetting( $string_type, $email_type );
         if ( ! $test ) {
@@ -694,7 +693,9 @@ class Emails
         }
         $string = $test;
         $this->switchLanguage( $order_language );
+      }
 
+        // Perform the translation
         $test = pll_translate_string( $string, $order_language );
         if ( $test != $string ) {
           $string = $test;
@@ -702,7 +703,6 @@ class Emails
           // If no user translation found in Polylang Strings Translations table, use WooCommerce default translation
           $string = __( $this->default_settings[ $email_type . '_' . $string_type ], 'woocommerce' );
         }
-      }
 
         if ($order) {
             $find    = array();

--- a/src/Hyyan/WPI/Emails.php
+++ b/src/Hyyan/WPI/Emails.php
@@ -696,30 +696,30 @@ class Emails
         $this->switchLanguage( $order_language );
       }
 
-        // Perform the translation
-        $test = pll_translate_string( $string, $order_language );
-        if ( $test != $string ) {
-          $string = $test;
-        } else {
-          // If no user translation found in Polylang Strings Translations table, use WooCommerce default translation
-          $string = __( $this->default_settings[ $email_type . '_' . $string_type ], 'woocommerce' );
-        }
+      // Perform the translation
+      $test = pll_translate_string( $string, $order_language );
+      if ( $test != $string ) {
+        $string = $test;
+      } else {
+        // If no user translation found in Polylang Strings Translations table, use WooCommerce default translation
+        $string = __( $this->default_settings[ $email_type . '_' . $string_type ], 'woocommerce' );
+      }
 
-        if ($order) {
-            $find    = array();
-            $replace = array();
+      if ($order) {
+        $find    = array();
+        $replace = array();
 
-            $find['order-date']   = '{order_date}';
-            $find['order-number'] = '{order_number}';
-            $find['site_title']   = '{site_title}';
+        $find['order-date']   = '{order_date}';
+        $find['order-number'] = '{order_number}';
+        $find['site_title']   = '{site_title}';
 
-            $replace['order-date']   = date_i18n(wc_date_format(), strtotime($order->get_date_created()));
-            $replace['order-number'] = $order->get_order_number();
-            $replace['site_title']   = get_bloginfo('name');
+        $replace['order-date']   = date_i18n(wc_date_format(), strtotime($order->get_date_created()));
+        $replace['order-number'] = $order->get_order_number();
+        $replace['site_title']   = get_bloginfo('name');
 
-            $string = str_replace(apply_filters(HooksInterface::EMAILS_ORDER_FIND_REPLACE_FIND_FILTER, $find, $order), apply_filters(HooksInterface::EMAILS_ORDER_FIND_REPLACE_REPLACE_FILTER, $replace, $order), $string);
-        }
-        return $string;
+        $string = str_replace(apply_filters(HooksInterface::EMAILS_ORDER_FIND_REPLACE_FIND_FILTER, $find, $order), apply_filters(HooksInterface::EMAILS_ORDER_FIND_REPLACE_REPLACE_FILTER, $replace, $order), $string);
+      }
+      return $string;
     }
 
     /**


### PR DESCRIPTION
Fixes introduced by 89ca15df970ee410513200954f0993fcf0ab93f9 added a comparison of the current locale with the order one to determine whether the content should be translated or not.

[Two variables have been introduced](https://github.com/hyyan/woo-poly-integration/commit/89ca15df970ee410513200954f0993fcf0ab93f9#diff-69fcb943770f73661e1cb4d114de1460R681) `$locale`  based on `get_locale` & `$baseLocale` based on `WPLANG`.
Sadly `get_locale` helper is hookable and contextual and might not return the right locale.

During my debugging session I ended up with an email  title in one language and its subject in the other.

When I saw that the `$baseLocale` variable was present I decided to use the global WP locale of the site instead of the helper, and it fixed my issues.

Since this is an edit of your code @Jon007 what do you think?

Fix #415
Fix #416 