### PR TITLE
Update FlashMessages.php for PHP Warning:  Illegal string offset 'wpi-support'

### DIFF
--- a/src/Hyyan/WPI/Tools/FlashMessages.php
+++ b/src/Hyyan/WPI/Tools/FlashMessages.php
@@ -49,7 +49,7 @@ final class FlashMessages
         if (isset($messages[$id])) {
             $messages[$id] = array_replace_recursive($messages[$id], $data);
         } else {
-            $messages[$id] = $data;
+            $messages = $data;
         }
 
         update_option(static::getOptionName(), $messages);


### PR DESCRIPTION
Fixed PHP Warning:  Illegal string offset 'wpi-support' in woo-poly-integration\src\Hyyan\WPI\Tools\FlashMessages.php.