### PR TITLE
fix static::getMessages() return non array.

### DIFF
--- a/src/Hyyan/WPI/Tools/FlashMessages.php
+++ b/src/Hyyan/WPI/Tools/FlashMessages.php
@@ -37,7 +37,8 @@ final class FlashMessages
      */
     public static function add($id, $message, array $classes = array('updated'), $persist = false)
     {
-        $messages = static::getMessages();
+	$messages = static::getMessages();
+        is_array( $messages ) ?: $messages = [];
         $data = array(
             'id' => $id,
             'message' => $message,


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

- Please make sure your changes respect the PSR-2 Coding Standards:
  - http://www.php-fig.org/psr/psr-2/
- In case you introduced a new action or filter hook, please use HooksInterface.php to document it 
- Please create tests, if you can.
-->

This pull request fixes static::getMessages() return non array.

#### What's Included in This Pull Request

* 
* 
* 
